### PR TITLE
Feature/13/Tag Submit Logic 구현

### DIFF
--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		D20FA2AB2A6BE34D0081B039 /* Encodable+toDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2AA2A6BE34D0081B039 /* Encodable+toDictionary.swift */; };
 		D23037782A8C65E40017950E /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23037772A8C65E40017950E /* SystemMessageCell.swift */; };
 		D24DF9C22A968FA30066C5B3 /* MockTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C12A968FA30066C5B3 /* MockTag.swift */; };
+		D24DF9C42A9695BB0066C5B3 /* TagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */; };
 		D25E3EC62A8C7038006AD283 /* ButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25E3EC52A8C7038006AD283 /* ButtonCell.swift */; };
 		D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */; };
 		D2C2476B2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */; };
@@ -123,6 +124,7 @@
 		D20FA2AA2A6BE34D0081B039 /* Encodable+toDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+toDictionary.swift"; sourceTree = "<group>"; };
 		D23037772A8C65E40017950E /* SystemMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCell.swift; sourceTree = "<group>"; };
 		D24DF9C12A968FA30066C5B3 /* MockTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTag.swift; sourceTree = "<group>"; };
+		D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStorage.swift; sourceTree = "<group>"; };
 		D25E3EC52A8C7038006AD283 /* ButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonCell.swift; sourceTree = "<group>"; };
 		D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStorage.swift; sourceTree = "<group>"; };
 		D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonMessageCellSizeCalculator.swift; sourceTree = "<group>"; };
@@ -458,6 +460,7 @@
 			isa = PBXGroup;
 			children = (
 				D24DF9C12A968FA30066C5B3 /* MockTag.swift */,
+				D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */,
 				D2F8C57D2A8F4AEF00AA3BFC /* CustomTagContentCell.swift */,
 				D2F8C5812A8F538500AA3BFC /* TagView */,
 				D2F8C5782A8F47CC00AA3BFC /* SizeCalculator */,
@@ -600,6 +603,7 @@
 				573BCD232A8F43B200116D2D /* HomeCoordinator.swift in Sources */,
 				D20FA2932A6BB3C40081B039 /* MultiMoyaProvider.swift in Sources */,
 				573BCD602A93167200116D2D /* Chat.swift in Sources */,
+				D24DF9C42A9695BB0066C5B3 /* TagStorage.swift in Sources */,
 				D20FA29A2A6BB9E20081B039 /* LabelDectionDTO.swift in Sources */,
 				573BCD562A925BA700116D2D /* ChatListViewController.swift in Sources */,
 				573BCD5C2A925C3700116D2D /* ChatListCoordinator.swift in Sources */,

--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		D23037782A8C65E40017950E /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23037772A8C65E40017950E /* SystemMessageCell.swift */; };
 		D24DF9C22A968FA30066C5B3 /* MockTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C12A968FA30066C5B3 /* MockTag.swift */; };
 		D24DF9C42A9695BB0066C5B3 /* TagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */; };
+		D24DF9C62A9876620066C5B3 /* CustomTagContentCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C52A9876620066C5B3 /* CustomTagContentCellViewModel.swift */; };
 		D25E3EC62A8C7038006AD283 /* UploadButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25E3EC52A8C7038006AD283 /* UploadButtonCell.swift */; };
 		D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */; };
 		D2C2476B2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */; };
@@ -125,6 +126,7 @@
 		D23037772A8C65E40017950E /* SystemMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCell.swift; sourceTree = "<group>"; };
 		D24DF9C12A968FA30066C5B3 /* MockTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTag.swift; sourceTree = "<group>"; };
 		D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStorage.swift; sourceTree = "<group>"; };
+		D24DF9C52A9876620066C5B3 /* CustomTagContentCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTagContentCellViewModel.swift; sourceTree = "<group>"; };
 		D25E3EC52A8C7038006AD283 /* UploadButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadButtonCell.swift; sourceTree = "<group>"; };
 		D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStorage.swift; sourceTree = "<group>"; };
 		D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonMessageCellSizeCalculator.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				D2E3AA252A8B62320049DDEF /* ChatViewController.swift */,
 				D2E3AA272A8B62400049DDEF /* ChatViewModel.swift */,
 				573BCD472A92146F00116D2D /* RecommendationCellViewModel.swift */,
+				D24DF9C52A9876620066C5B3 /* CustomTagContentCellViewModel.swift */,
 				573BCD252A8F46B900116D2D /* ChatCoordinator.swift */,
 			);
 			path = Chat;
@@ -607,6 +610,7 @@
 				D20FA29A2A6BB9E20081B039 /* LabelDectionDTO.swift in Sources */,
 				573BCD562A925BA700116D2D /* ChatListViewController.swift in Sources */,
 				573BCD5C2A925C3700116D2D /* ChatListCoordinator.swift in Sources */,
+				D24DF9C62A9876620066C5B3 /* CustomTagContentCellViewModel.swift in Sources */,
 				D23037782A8C65E40017950E /* SystemMessageCell.swift in Sources */,
 				573BCD4A2A92149F00116D2D /* RecommendationItemCell.swift in Sources */,
 				D20FA2A22A6BC8650081B039 /* GoogleVisionRepository.swift in Sources */,

--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		D23037782A8C65E40017950E /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23037772A8C65E40017950E /* SystemMessageCell.swift */; };
 		D24DF9C22A968FA30066C5B3 /* MockTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C12A968FA30066C5B3 /* MockTag.swift */; };
 		D24DF9C42A9695BB0066C5B3 /* TagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */; };
-		D25E3EC62A8C7038006AD283 /* ButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25E3EC52A8C7038006AD283 /* ButtonCell.swift */; };
+		D25E3EC62A8C7038006AD283 /* UploadButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25E3EC52A8C7038006AD283 /* UploadButtonCell.swift */; };
 		D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */; };
 		D2C2476B2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */; };
 		D2E3AA262A8B62320049DDEF /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E3AA252A8B62320049DDEF /* ChatViewController.swift */; };
@@ -125,7 +125,7 @@
 		D23037772A8C65E40017950E /* SystemMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCell.swift; sourceTree = "<group>"; };
 		D24DF9C12A968FA30066C5B3 /* MockTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTag.swift; sourceTree = "<group>"; };
 		D24DF9C32A9695BB0066C5B3 /* TagStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStorage.swift; sourceTree = "<group>"; };
-		D25E3EC52A8C7038006AD283 /* ButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonCell.swift; sourceTree = "<group>"; };
+		D25E3EC52A8C7038006AD283 /* UploadButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadButtonCell.swift; sourceTree = "<group>"; };
 		D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStorage.swift; sourceTree = "<group>"; };
 		D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonMessageCellSizeCalculator.swift; sourceTree = "<group>"; };
 		D2E3AA252A8B62320049DDEF /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
@@ -418,7 +418,7 @@
 			isa = PBXGroup;
 			children = (
 				D23037772A8C65E40017950E /* SystemMessageCell.swift */,
-				D25E3EC52A8C7038006AD283 /* ButtonCell.swift */,
+				D25E3EC52A8C7038006AD283 /* UploadButtonCell.swift */,
 			);
 			path = DefaultSystemSectionCell;
 			sourceTree = "<group>";
@@ -638,7 +638,7 @@
 				573BCD5A2A925C2F00116D2D /* ChatListViewModel.swift in Sources */,
 				D20FA2752A6B8DA90081B039 /* SceneDelegate.swift in Sources */,
 				D2E81B8E2A913AF8006A5236 /* TagCollectionHeaderView.swift in Sources */,
-				D25E3EC62A8C7038006AD283 /* ButtonCell.swift in Sources */,
+				D25E3EC62A8C7038006AD283 /* UploadButtonCell.swift in Sources */,
 				57C100192A8B91E700A664FD /* Color.swift in Sources */,
 				D2F8C57E2A8F4AEF00AA3BFC /* CustomTagContentCell.swift in Sources */,
 				573BCD6B2A936F0D00116D2D /* UIImage+resize.swift in Sources */,

--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -20,18 +20,18 @@
 		573BCD232A8F43B200116D2D /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD022A8BAF7600116D2D /* HomeCoordinator.swift */; };
 		573BCD242A8F43BD00116D2D /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD002A8BAF7600116D2D /* HomeViewModel.swift */; };
 		573BCD262A8F46B900116D2D /* ChatCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD252A8F46B900116D2D /* ChatCoordinator.swift */; };
-		573BCD562A925BA700116D2D /* ChatListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD552A925BA700116D2D /* ChatListViewController.swift */; };
-		573BCD5A2A925C2F00116D2D /* ChatListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD592A925C2F00116D2D /* ChatListViewModel.swift */; };
-		573BCD5C2A925C3700116D2D /* ChatListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD5B2A925C3700116D2D /* ChatListCoordinator.swift */; };
-		573BCD5E2A92618500116D2D /* ChatListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD5D2A92618500116D2D /* ChatListCell.swift */; };
-		573BCD602A93167200116D2D /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD5F2A93167200116D2D /* Chat.swift */; };
-		573BCD642A934D4500116D2D /* DateFormatter+shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD632A934D4500116D2D /* DateFormatter+shared.swift */; };
 		573BCD382A91DA6500116D2D /* RecommendationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD372A91DA6500116D2D /* RecommendationItem.swift */; };
 		573BCD412A91FE7700116D2D /* RecommendationCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD402A91FE7700116D2D /* RecommendationCellSizeCalculator.swift */; };
 		573BCD432A920D2E00116D2D /* SystemMessageCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD422A920D2E00116D2D /* SystemMessageCellSizeCalculator.swift */; };
 		573BCD462A92141500116D2D /* RecommendationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD452A92141500116D2D /* RecommendationCell.swift */; };
 		573BCD482A92146F00116D2D /* RecommendationCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD472A92146F00116D2D /* RecommendationCellViewModel.swift */; };
 		573BCD4A2A92149F00116D2D /* RecommendationItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD492A92149F00116D2D /* RecommendationItemCell.swift */; };
+		573BCD562A925BA700116D2D /* ChatListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD552A925BA700116D2D /* ChatListViewController.swift */; };
+		573BCD5A2A925C2F00116D2D /* ChatListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD592A925C2F00116D2D /* ChatListViewModel.swift */; };
+		573BCD5C2A925C3700116D2D /* ChatListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD5B2A925C3700116D2D /* ChatListCoordinator.swift */; };
+		573BCD5E2A92618500116D2D /* ChatListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD5D2A92618500116D2D /* ChatListCell.swift */; };
+		573BCD602A93167200116D2D /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD5F2A93167200116D2D /* Chat.swift */; };
+		573BCD642A934D4500116D2D /* DateFormatter+shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD632A934D4500116D2D /* DateFormatter+shared.swift */; };
 		573BCD692A9365B300116D2D /* AvatarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD682A9365B300116D2D /* AvatarHeaderView.swift */; };
 		573BCD6B2A936F0D00116D2D /* UIImage+resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573BCD6A2A936F0D00116D2D /* UIImage+resize.swift */; };
 		57684BF92A73CAFE008AB8C9 /* OpenAIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57684BF82A73CAFE008AB8C9 /* OpenAIRepository.swift */; };
@@ -52,6 +52,7 @@
 		D20FA2A82A6BD4830081B039 /* GoogleVisionRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2A72A6BD4830081B039 /* GoogleVisionRequestModel.swift */; };
 		D20FA2AB2A6BE34D0081B039 /* Encodable+toDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2AA2A6BE34D0081B039 /* Encodable+toDictionary.swift */; };
 		D23037782A8C65E40017950E /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23037772A8C65E40017950E /* SystemMessageCell.swift */; };
+		D24DF9C22A968FA30066C5B3 /* MockTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DF9C12A968FA30066C5B3 /* MockTag.swift */; };
 		D25E3EC62A8C7038006AD283 /* ButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25E3EC52A8C7038006AD283 /* ButtonCell.swift */; };
 		D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */; };
 		D2C2476B2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */; };
@@ -89,18 +90,18 @@
 		573BCD1C2A8E682200116D2D /* BottomMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomMenuItem.swift; sourceTree = "<group>"; };
 		573BCD212A8F42DA00116D2D /* SecretStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecretStorage.swift; sourceTree = "<group>"; };
 		573BCD252A8F46B900116D2D /* ChatCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCoordinator.swift; sourceTree = "<group>"; };
-		573BCD552A925BA700116D2D /* ChatListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewController.swift; sourceTree = "<group>"; };
-		573BCD592A925C2F00116D2D /* ChatListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewModel.swift; sourceTree = "<group>"; };
-		573BCD5B2A925C3700116D2D /* ChatListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListCoordinator.swift; sourceTree = "<group>"; };
-		573BCD5D2A92618500116D2D /* ChatListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListCell.swift; sourceTree = "<group>"; };
-		573BCD5F2A93167200116D2D /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
-		573BCD632A934D4500116D2D /* DateFormatter+shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+shared.swift"; sourceTree = "<group>"; };
 		573BCD372A91DA6500116D2D /* RecommendationItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationItem.swift; sourceTree = "<group>"; };
 		573BCD402A91FE7700116D2D /* RecommendationCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationCellSizeCalculator.swift; sourceTree = "<group>"; };
 		573BCD422A920D2E00116D2D /* SystemMessageCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCellSizeCalculator.swift; sourceTree = "<group>"; };
 		573BCD452A92141500116D2D /* RecommendationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationCell.swift; sourceTree = "<group>"; };
 		573BCD472A92146F00116D2D /* RecommendationCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationCellViewModel.swift; sourceTree = "<group>"; };
 		573BCD492A92149F00116D2D /* RecommendationItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationItemCell.swift; sourceTree = "<group>"; };
+		573BCD552A925BA700116D2D /* ChatListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewController.swift; sourceTree = "<group>"; };
+		573BCD592A925C2F00116D2D /* ChatListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewModel.swift; sourceTree = "<group>"; };
+		573BCD5B2A925C3700116D2D /* ChatListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListCoordinator.swift; sourceTree = "<group>"; };
+		573BCD5D2A92618500116D2D /* ChatListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListCell.swift; sourceTree = "<group>"; };
+		573BCD5F2A93167200116D2D /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
+		573BCD632A934D4500116D2D /* DateFormatter+shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+shared.swift"; sourceTree = "<group>"; };
 		573BCD682A9365B300116D2D /* AvatarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarHeaderView.swift; sourceTree = "<group>"; };
 		573BCD6A2A936F0D00116D2D /* UIImage+resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+resize.swift"; sourceTree = "<group>"; };
 		57684BF82A73CAFE008AB8C9 /* OpenAIRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRepository.swift; sourceTree = "<group>"; };
@@ -121,6 +122,7 @@
 		D20FA2A72A6BD4830081B039 /* GoogleVisionRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleVisionRequestModel.swift; sourceTree = "<group>"; };
 		D20FA2AA2A6BE34D0081B039 /* Encodable+toDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+toDictionary.swift"; sourceTree = "<group>"; };
 		D23037772A8C65E40017950E /* SystemMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCell.swift; sourceTree = "<group>"; };
+		D24DF9C12A968FA30066C5B3 /* MockTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTag.swift; sourceTree = "<group>"; };
 		D25E3EC52A8C7038006AD283 /* ButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonCell.swift; sourceTree = "<group>"; };
 		D2833A2F2A8E1578000FEE30 /* MessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStorage.swift; sourceTree = "<group>"; };
 		D2C2476A2A93606800C547EC /* ButtonMessageCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonMessageCellSizeCalculator.swift; sourceTree = "<group>"; };
@@ -214,6 +216,16 @@
 			path = Secrets;
 			sourceTree = "<group>";
 		};
+		573BCD442A92140900116D2D /* RecommendationCell */ = {
+			isa = PBXGroup;
+			children = (
+				573BCD452A92141500116D2D /* RecommendationCell.swift */,
+				573BCD682A9365B300116D2D /* AvatarHeaderView.swift */,
+				573BCD492A92149F00116D2D /* RecommendationItemCell.swift */,
+			);
+			path = RecommendationCell;
+			sourceTree = "<group>";
+		};
 		573BCD542A925B9B00116D2D /* ChatList */ = {
 			isa = PBXGroup;
 			children = (
@@ -239,16 +251,6 @@
 				573BCD592A925C2F00116D2D /* ChatListViewModel.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		573BCD442A92140900116D2D /* RecommendationCell */ = {
-			isa = PBXGroup;
-			children = (
-				573BCD452A92141500116D2D /* RecommendationCell.swift */,
-				573BCD682A9365B300116D2D /* AvatarHeaderView.swift */,
-				573BCD492A92149F00116D2D /* RecommendationItemCell.swift */,
-			);
-			path = RecommendationCell;
 			sourceTree = "<group>";
 		};
 		57C100162A8B91CF00A664FD /* Resources */ = {
@@ -455,6 +457,7 @@
 		D2F8C5762A8F47A800AA3BFC /* CustomTagCell */ = {
 			isa = PBXGroup;
 			children = (
+				D24DF9C12A968FA30066C5B3 /* MockTag.swift */,
 				D2F8C57D2A8F4AEF00AA3BFC /* CustomTagContentCell.swift */,
 				D2F8C5812A8F538500AA3BFC /* TagView */,
 				D2F8C5782A8F47CC00AA3BFC /* SizeCalculator */,
@@ -615,6 +618,7 @@
 				573BCD152A8D21E800116D2D /* Font.swift in Sources */,
 				573BCD642A934D4500116D2D /* DateFormatter+shared.swift in Sources */,
 				573BCCFE2A8BAE4100116D2D /* Coordinator.swift in Sources */,
+				D24DF9C22A968FA30066C5B3 /* MockTag.swift in Sources */,
 				D2E3AA282A8B62400049DDEF /* ChatViewModel.swift in Sources */,
 				D20FA2AB2A6BE34D0081B039 /* Encodable+toDictionary.swift in Sources */,
 				573BCD1D2A8E682200116D2D /* BottomMenuItem.swift in Sources */,

--- a/TravelGenie/TravelGenie/Domain/Model/Message.swift
+++ b/TravelGenie/TravelGenie/Domain/Model/Message.swift
@@ -89,3 +89,11 @@ struct Message: MessageType {
         self.sentDate = sentDate
     }
 }
+
+extension Message {
+    init(mockTags: [MockTag]) {
+        let mockTagItem = MockTagItem(tags: mockTags)
+        
+        self.init(kind: .custom(mockTagItem), sender: Sender(name: .ai), messageId: UUID().uuidString, sentDate: Date())
+    }
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -9,11 +9,7 @@ import UIKit
 import MessageKit
 
 final class CustomTagContentCell: UICollectionViewCell {
-    private var tagStorage: TagStorage = TagStorage() {
-        didSet {
-            tagCollectionView.reloadData()
-        }
-    }
+    private var tagStorage: TagStorage = TagStorage()
     
     private let tagContentAvatarView = AvatarView()
     private let messageContentView = UIView()

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import MessageKit
 
 final class CustomTagContentCell: UICollectionViewCell {
-    var tagList: [Tag] = [] {
+    private var tagStorage: TagStorage = TagStorage() {
         didSet {
             tagCollectionView.reloadData()
         }
@@ -37,9 +37,9 @@ final class CustomTagContentCell: UICollectionViewCell {
         with message: MessageType)
     {
         if case .custom(let tagItem) = message.kind {
-            guard let tagItem = tagItem as? TagItem else { return }
+            guard let tagItem = tagItem as? MockTagItem else { return }
             
-            tagList = tagItem.tags
+            tagStorage.insertTags(tags: tagItem.tags)
         }
     }
     
@@ -159,9 +159,9 @@ extension CustomTagContentCell: UICollectionViewDataSource {
         
         switch section {
         case .location:
-            return 2
+            return tagStorage.locationTagList.count
         case .theme:
-            return tagList.count
+            return tagStorage.themeTagList.count
         }
     }
     
@@ -175,13 +175,9 @@ extension CustomTagContentCell: UICollectionViewDataSource {
         if let section = Section(rawValue: indexPath.section) {
             switch section {
             case .location:
-                let defaultTag = [
-                    Tag(text: "국내"),
-                    Tag(text: "해외")
-                ]
-                cell.configure(tag: defaultTag[indexPath.item])
+                cell.configure(tag: tagStorage.locationTagList[indexPath.item])
             case .theme:
-                cell.configure(tag: tagList[indexPath.item])
+                cell.configure(tag: tagStorage.themeTagList[indexPath.item])
             }
         }
 
@@ -227,7 +223,7 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
                 let twoCharacterCellSize = CGSize(width: 74, height: 47)
                 return twoCharacterCellSize
             case .theme:
-                let numberOfCharactersInTag = tagList[indexPath.item].text.count
+                let numberOfCharactersInTag = tagStorage.themeTagList[indexPath.item].text.count
                 let defaultHeight: CGFloat = 47 // 고정높이
                 let defaultWidth: CGFloat = 48 // 비어있는 태그의 tagCell의 width
                 let additionalWidthForOneCharacterSize: CGFloat = 13.0

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -298,7 +298,7 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
 }
 
 extension CustomTagContentCell: TagSelectionDelegate {
-    func tagDidSelect(withText text: String, isOn: Bool) {
-        tagStorage.updateTagIsOn(text: text, isOn: isOn)
+    func tagDidSelect(withText value: String, isSelected: Bool) {
+        tagStorage.updateTagIsOn(value: value, isSelected: isSelected)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -35,9 +35,7 @@ final class CustomTagContentCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(
-        with message: MessageType)
-    {
+    func configure(with message: MessageType) {
         if case .custom(let tagItem) = message.kind {
             guard let tagItem = tagItem as? MockTagItem else { return }
             
@@ -299,6 +297,6 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
 
 extension CustomTagContentCell: TagSelectionDelegate {
     func tagDidSelect(withText value: String, isSelected: Bool) {
-        tagStorage.updateTagIsOn(value: value, isSelected: isSelected)
+        tagStorage.updateTagIsSelected(value: value, isSelected: isSelected)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -101,7 +101,7 @@ final class CustomTagContentCell: UICollectionViewCell {
     private func configureSubmitKeywordButtonAction() {
         let buttonAction = UIAction { [weak self] _ in
             guard let self,
-                  let selectedList = self.tagStorage.getSelectedList() else {
+                  let selectedList = self.tagStorage.getSelectedTags() else {
                 print("선택된 태그 없음.")
                 return
             }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -101,7 +101,7 @@ final class CustomTagContentCell: UICollectionViewCell {
     private func configureSubmitKeywordButtonAction() {
         let buttonAction = UIAction { [weak self] _ in
             guard let self,
-                  let selectedList = tagStorage.getSelectedList() else {
+                  let selectedList = self.tagStorage.getSelectedList() else {
                 print("선택된 태그 없음.")
                 return
             }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -185,6 +185,8 @@ extension CustomTagContentCell: UICollectionViewDataSource {
             }
         }
 
+        cell.delegate = self
+        
         return cell
     }
     
@@ -279,5 +281,11 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         if messageContentViewHeightLayoutConstraint?.constant != totalContentHeight {
             messageContentViewHeightLayoutConstraint?.constant = totalContentHeight
         }
+    }
+}
+
+extension CustomTagContentCell: TagSelectionDelegate {
+    func tagDidSelect(withText text: String) {
+        print(text)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -8,7 +8,13 @@
 import UIKit
 import MessageKit
 
+protocol TagSubmissionDelegate: AnyObject {
+    func submitSelectedTags(_ selectedTagList: [MockTag])
+}
+
 final class CustomTagContentCell: UICollectionViewCell {
+    weak var delegate: TagSubmissionDelegate?
+    
     private var tagStorage: TagStorage = TagStorage()
     
     private let tagContentAvatarView = AvatarView()
@@ -40,7 +46,7 @@ final class CustomTagContentCell: UICollectionViewCell {
     }
     
     private func configureSubviews() {
-        configureSubmitButton()
+        configureSubmitKeywordButton()
         configureTagCollectionView()
         configureMessageContentView()
         configureDefaultMessageLabel()
@@ -82,13 +88,28 @@ final class CustomTagContentCell: UICollectionViewCell {
         tagCollectionView.translatesAutoresizingMaskIntoConstraints = false
     }
     
-    private func configureSubmitButton() {
+    private func configureSubmitKeywordButton() {
         let titleText = NSMutableAttributedString()
             .text("키워드 보내기", font: .bodyRegular, color: .black)
         
+        configureSubmitKeywordButtonAction()
         submitKeywordButton.layer.cornerRadius = 12
         submitKeywordButton.backgroundColor = .blueGrayBackground3
         submitKeywordButton.setAttributedTitle(titleText, for: .normal)
+    }
+    
+    private func configureSubmitKeywordButtonAction() {
+        let buttonAction = UIAction { [weak self] _ in
+            guard let self,
+                  let selectedList = tagStorage.getSelectedList() else {
+                print("선택된 태그 없음.")
+                return
+            }
+            
+            self.delegate?.submitSelectedTags(selectedList)
+        }
+        
+        submitKeywordButton.addAction(buttonAction, for: .touchUpInside)
     }
     
     private func configureHierarchy() {

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -281,7 +281,7 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
 }
 
 extension CustomTagContentCell: TagSelectionDelegate {
-    func tagDidSelect(withText text: String) {
-        print(text)
+    func tagDidSelect(withText text: String, isOn: Bool) {
+        tagStorage.updateTagIsOn(text: text, isOn: isOn)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import MessageKit
 
 protocol TagSubmissionDelegate: AnyObject {
-    func submitSelectedTags(_ isSelectedTags: [MockTag])
+    func submitSelectedTags(_ selectedTags: [MockTag])
 }
 
 final class CustomTagContentCell: UICollectionViewCell {

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/MockTag.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/MockTag.swift
@@ -1,0 +1,17 @@
+//
+//  MockTag.swift
+//  TravelGenie
+//
+//  Created by 서현웅 on 2023/08/24.
+//
+
+import Foundation
+
+struct MockTag {
+    let text: String
+    let isOn: Bool = false
+}
+
+struct MockTagItem {
+    var tags: [MockTag]
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/MockTag.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/MockTag.swift
@@ -10,7 +10,7 @@ import Foundation
 struct MockTag {
     let category: Category
     let text: String
-    let isOn: Bool = false
+    var isOn: Bool = false
 }
 
 struct MockTagItem {

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/MockTag.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/MockTag.swift
@@ -8,10 +8,16 @@
 import Foundation
 
 struct MockTag {
+    let category: Category
     let text: String
     let isOn: Bool = false
 }
 
 struct MockTagItem {
     var tags: [MockTag]
+}
+
+enum Category {
+    case location
+    case theme
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -30,6 +30,12 @@ final class TagStorage {
         tags.forEach { tagList.append($0) }
     }
     
+    func updateTagIsOn(text: String, isOn: Bool) {
+        if let index = tagList.firstIndex(where: { $0.text == text }) {
+            tagList[index].isOn = isOn
+        }
+    }
+    
     private func setDefaultTagList() -> [MockTag] {
         let defaultTag = [
             MockTag(category: .location, text: "국내"),
@@ -38,5 +44,4 @@ final class TagStorage {
         
         return defaultTag
     }
-    
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -8,39 +8,39 @@
 import Foundation
 
 final class TagStorage {
-    private var tagList = [MockTag]()
+    private var tags = [MockTag]()
     
     var count: Int {
-        return tagList.count
+        return tags.count
     }
     
     var locationTagList: [MockTag] {
-        return tagList.filter { $0.category == .location }
+        return tags.filter { $0.category == .location }
     }
     
     var themeTagList: [MockTag] {
-        return tagList.filter { $0.category == .theme }
+        return tags.filter { $0.category == .theme }
     }
     
     private var selectedTagList: [MockTag] {
-        return tagList.filter { $0.isOn == true }
+        return tags.filter { $0.isOn == true }
     }
     
     init() {
-        self.tagList = setDefaultTagList()
+        self.tags = setDefaultTagList()
     }
     
     func getSelectedTags() -> [MockTag]? {
         return selectedTagList.isEmpty ? nil : selectedTagList
     }
     
-    func insertTags(tags: [MockTag]) {
-        tags.forEach { tagList.append($0) }
+    func insertTags(_ tags: [MockTag]) {
+        tags.forEach { self.tags.append($0) }
     }
     
     func updateTagIsSelected(value: String, isSelected: Bool) {
-        if let index = tagList.firstIndex(where: { $0.text == value }) {
-            tagList[index].isOn = isSelected
+        if let index = tags.firstIndex(where: { $0.text == value }) {
+            tags[index].isOn = isSelected
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -14,24 +14,24 @@ final class TagStorage {
         return tags.count
     }
     
-    var locationTagList: [MockTag] {
+    var locationTags: [MockTag] {
         return tags.filter { $0.category == .location }
     }
     
-    var themeTagList: [MockTag] {
+    var themeTags: [MockTag] {
         return tags.filter { $0.category == .theme }
     }
     
-    private var selectedTagList: [MockTag] {
+    private var selectedTags: [MockTag] {
         return tags.filter { $0.isOn == true }
     }
     
     init() {
-        self.tags = setDefaultTagList()
+        tags = setDefaultTags()
     }
     
     func getSelectedTags() -> [MockTag]? {
-        return selectedTagList.isEmpty ? nil : selectedTagList
+        return selectedTags.isEmpty ? nil : selectedTags
     }
     
     func insertTags(_ tags: [MockTag]) {
@@ -44,7 +44,7 @@ final class TagStorage {
         }
     }
     
-    private func setDefaultTagList() -> [MockTag] {
+    private func setDefaultTags() -> [MockTag] {
         let defaultTag = [
             MockTag(category: .location, text: "국내"),
             MockTag(category: .location, text: "해외")

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -38,9 +38,9 @@ final class TagStorage {
         tags.forEach { tagList.append($0) }
     }
     
-    func updateTagIsOn(text: String, isOn: Bool) {
-        if let index = tagList.firstIndex(where: { $0.text == text }) {
-            tagList[index].isOn = isOn
+    func updateTagIsOn(value: String, isSelected: Bool) {
+        if let index = tagList.firstIndex(where: { $0.text == value }) {
+            tagList[index].isOn = isSelected
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -38,7 +38,7 @@ final class TagStorage {
         tags.forEach { self.tags.append($0) }
     }
     
-    func updateTagIsSelected(value: String, isSelected: Bool) {
+    func updateTagSelectionState(value: String, isSelected: Bool) {
         if let index = tags.firstIndex(where: { $0.text == value }) {
             tags[index].isOn = isSelected
         }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -38,7 +38,7 @@ final class TagStorage {
         tags.forEach { tagList.append($0) }
     }
     
-    func updateTagIsOn(value: String, isSelected: Bool) {
+    func updateTagIsSelected(value: String, isSelected: Bool) {
         if let index = tagList.firstIndex(where: { $0.text == value }) {
             tagList[index].isOn = isSelected
         }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -22,8 +22,16 @@ final class TagStorage {
         return tagList.filter { $0.category == .theme }
     }
     
+    private var selectedTagList: [MockTag] {
+        return tagList.filter { $0.isOn == true }
+    }
+    
     init() {
         self.tagList = setDefaultTagList()
+    }
+    
+    func getSelectedList() -> [MockTag]? {
+        return selectedTagList.isEmpty ? nil : selectedTagList
     }
     
     func insertTags(tags: [MockTag]) {

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -1,0 +1,42 @@
+//
+//  TagStorage.swift
+//  TravelGenie
+//
+//  Created by 서현웅 on 2023/08/24.
+//
+
+import Foundation
+
+final class TagStorage {
+    private var tagList = [MockTag]()
+    
+    var count: Int {
+        return tagList.count
+    }
+    
+    var locationTagList: [MockTag] {
+        return tagList.filter { $0.category == .location }
+    }
+    
+    var themeTagList: [MockTag] {
+        return tagList.filter { $0.category == .theme }
+    }
+    
+    init() {
+        self.tagList = setDefaultTagList()
+    }
+    
+    func insertTags(tags: [MockTag]) {
+        tags.forEach { tagList.append($0) }
+    }
+    
+    private func setDefaultTagList() -> [MockTag] {
+        let defaultTag = [
+            MockTag(category: .location, text: "국내"),
+            MockTag(category: .location, text: "해외")
+        ]
+        
+        return defaultTag
+    }
+    
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagStorage.swift
@@ -30,7 +30,7 @@ final class TagStorage {
         self.tagList = setDefaultTagList()
     }
     
-    func getSelectedList() -> [MockTag]? {
+    func getSelectedTags() -> [MockTag]? {
         return selectedTagList.isEmpty ? nil : selectedTagList
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -59,8 +59,8 @@ class TagCollectionViewCell: UICollectionViewCell {
         let buttonAction = UIAction { [weak self] _ in
             guard let self else { return }
             self.tagButton.isSelected.toggle()
-            setButtonAttribute(sender: self.tagButton.state)
-            notifyTagSelection(sender: self.tagButton)
+            self.setButtonAttribute(sender: self.tagButton.state)
+            self.notifyTagSelection(sender: self.tagButton)
         }
         
         tagButton.addAction(buttonAction, for: .touchUpInside)

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol TagSelectionDelegate: AnyObject {
-    func tagDidSelect(withText text: String, isOn: Bool)
+    func tagDidSelect(withText text: String, isSelected: Bool)
 }
 
 class TagCollectionViewCell: UICollectionViewCell {
@@ -92,9 +92,9 @@ class TagCollectionViewCell: UICollectionViewCell {
         
         switch sender.state {
         case selectedState:
-            delegate?.tagDidSelect(withText: tagText, isOn: true)
+            delegate?.tagDidSelect(withText: tagText, isSelected: true)
         case deselectedState:
-            delegate?.tagDidSelect(withText: tagText, isOn: false)
+            delegate?.tagDidSelect(withText: tagText, isSelected: false)
         default:
             break
         }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -27,7 +27,7 @@ class TagCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(tag: Tag) {
+    func configure(tag: MockTag) {
         configureTagButtonText(tag: tag)
     }
     
@@ -43,7 +43,7 @@ class TagCollectionViewCell: UICollectionViewCell {
         self.tagButton.layer.borderColor = UIColor.blueGrayLine.cgColor
     }
     
-    private func configureTagButtonText(tag: Tag) {
+    private func configureTagButtonText(tag: MockTag) {
         let tagText = tag.text
         
         let defaultText = NSMutableAttributedString()

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -67,21 +67,26 @@ class TagCollectionViewCell: UICollectionViewCell {
     }
     
     private func setButtonAttribute(sender: UIButton.State) {
+        let selectedState: UIButton.State = [.highlighted, .selected]
+        let deselectedState: UIButton.State = .highlighted
+        
         switch sender {
-        case .highlighted:
+        case deselectedState:
             self.tagButton.backgroundColor = .white
             self.tagButton.layer.borderColor = UIColor.blueGrayLine.cgColor
             self.tagButton.layer.borderWidth = 1
-        default:
+        case selectedState:
             self.tagButton.backgroundColor = .tertiary
             self.tagButton.layer.borderColor = UIColor.primary.cgColor
             self.tagButton.layer.borderWidth = 2
+        default:
+            break
         }
     }
     
     private func notifyTagSelection(sender: UIButton) {
-        let selectedState = UIButton.State(rawValue: 5)
-        let deselectedState = UIButton.State(rawValue: 1)
+        let selectedState: UIButton.State = [.highlighted, .selected]
+        let deselectedState: UIButton.State = .highlighted
         
         guard let tagText = sender.titleLabel?.text else { return }
         

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol TagSelectionDelegate: AnyObject {
-    func tagDidSelect(withText text: String)
+    func tagDidSelect(withText text: String, isOn: Bool)
 }
 
 class TagCollectionViewCell: UICollectionViewCell {
@@ -80,12 +80,18 @@ class TagCollectionViewCell: UICollectionViewCell {
     }
     
     private func notifyTagSelection(sender: UIButton) {
-        let selectedRawValue = 5
+        let selectedState = UIButton.State(rawValue: 5)
+        let deselectedState = UIButton.State(rawValue: 1)
         
-        if sender.state.rawValue == selectedRawValue {
-            guard let tagText = sender.titleLabel?.text else { return }
-            
-            delegate?.tagDidSelect(withText: tagText)
+        guard let tagText = sender.titleLabel?.text else { return }
+        
+        switch sender.state {
+        case selectedState:
+            delegate?.tagDidSelect(withText: tagText, isOn: true)
+        case deselectedState:
+            delegate?.tagDidSelect(withText: tagText, isOn: false)
+        default:
+            break
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol TagSelectionDelegate: AnyObject {
+    func tagDidSelect(withText text: String)
+}
+
 class TagCollectionViewCell: UICollectionViewCell {
     static var identifier: String { return String(describing: self) }
     
+    weak var delegate: TagSelectionDelegate?
     private let tagButton: UIButton = UIButton()
     
     override init(frame: CGRect) {
@@ -55,12 +60,12 @@ class TagCollectionViewCell: UICollectionViewCell {
             guard let self else { return }
             self.tagButton.isSelected.toggle()
             setButtonAttribute(sender: self.tagButton.state)
+            print(self.tagButton.state)
+            notifyTagSelection(sender: self.tagButton)
         }
-        
         
         tagButton.addAction(buttonAction, for: .touchUpInside)
     }
-    
     
     private func setButtonAttribute(sender: UIButton.State) {
         switch sender {
@@ -72,6 +77,16 @@ class TagCollectionViewCell: UICollectionViewCell {
             self.tagButton.backgroundColor = .tertiary
             self.tagButton.layer.borderColor = UIColor.primary.cgColor
             self.tagButton.layer.borderWidth = 2
+        }
+    }
+    
+    private func notifyTagSelection(sender: UIButton) {
+        let selectedRawValue = 5
+        
+        if sender.state.rawValue == selectedRawValue {
+            guard let tagText = sender.titleLabel?.text else { return }
+            
+            delegate?.tagDidSelect(withText: tagText)
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -60,7 +60,6 @@ class TagCollectionViewCell: UICollectionViewCell {
             guard let self else { return }
             self.tagButton.isSelected.toggle()
             setButtonAttribute(sender: self.tagButton.state)
-            print(self.tagButton.state)
             notifyTagSelection(sender: self.tagButton)
         }
         

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -39,8 +39,8 @@ class TagCollectionViewCell: UICollectionViewCell {
         setButtonAction()
         tagButton.layer.cornerRadius = 24
         tagButton.layer.borderWidth = 1.0
-        self.tagButton.backgroundColor = .white
-        self.tagButton.layer.borderColor = UIColor.blueGrayLine.cgColor
+        tagButton.backgroundColor = .white
+        tagButton.layer.borderColor = UIColor.blueGrayLine.cgColor
     }
     
     private func configureTagButtonText(tag: MockTag) {

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -10,20 +10,11 @@ import UIKit
 class TagCollectionViewCell: UICollectionViewCell {
     static var identifier: String { return String(describing: self) }
     
-    private let tagButton: UIButton = {
-       let button = UIButton()
-        
-        button.layer.cornerRadius = 24
-        button.layer.borderWidth = 1.0
-        button.layer.borderColor = UIColor.blueGrayBackground.cgColor
-        button.backgroundColor = .white
-        button.translatesAutoresizingMaskIntoConstraints = false
-        
-        return button
-    }()
+    private let tagButton: UIButton = UIButton()
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
+        configureSubviews()
         configureLayout()
     }
     
@@ -32,16 +23,62 @@ class TagCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(tag: Tag) {
-        let text = tag.text
-        let title = NSMutableAttributedString()
-            .text("#\(text)", font: .bodyRegular, color: .black)
+        configureTagButtonText(tag: tag)
+    }
+    
+    private func configureSubviews() {
+        congirueTagButton()
+    }
+    
+    private func congirueTagButton() {
+        setButtonAction()
+        tagButton.layer.cornerRadius = 24
+        tagButton.layer.borderWidth = 1.0
+        self.tagButton.backgroundColor = .white
+        self.tagButton.layer.borderColor = UIColor.blueGrayLine.cgColor
+    }
+    
+    private func configureTagButtonText(tag: Tag) {
+        let tagText = tag.text
         
-        tagButton.setAttributedTitle(title, for: .normal)
+        let defaultText = NSMutableAttributedString()
+            .text(tagText, font: .bodyRegular, color: .black)
+        let selectedText = NSMutableAttributedString()
+            .text(tagText, font: .bodyBold, color: .primary)
+        
+        tagButton.setAttributedTitle(defaultText, for: .normal)
+        tagButton.setAttributedTitle(selectedText, for: .selected)
+    }
+    
+    private func setButtonAction() {
+        let buttonAction = UIAction { [weak self] _ in
+            guard let self else { return }
+            self.tagButton.isSelected.toggle()
+            setButtonAttribute(sender: self.tagButton.state)
+        }
+        
+        
+        tagButton.addAction(buttonAction, for: .touchUpInside)
+    }
+    
+    
+    private func setButtonAttribute(sender: UIButton.State) {
+        switch sender {
+        case .highlighted:
+            self.tagButton.backgroundColor = .white
+            self.tagButton.layer.borderColor = UIColor.blueGrayLine.cgColor
+            self.tagButton.layer.borderWidth = 1
+        default:
+            self.tagButton.backgroundColor = .tertiary
+            self.tagButton.layer.borderColor = UIColor.primary.cgColor
+            self.tagButton.layer.borderWidth = 2
+        }
     }
     
     private func configureLayout() {
         contentView.addSubview(tagButton)
         
+        tagButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             tagButton.topAnchor.constraint(equalTo: contentView.topAnchor),
             tagButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -49,6 +86,4 @@ class TagCollectionViewCell: UICollectionViewCell {
             tagButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
-    
-    
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
@@ -7,16 +7,16 @@
 
 import UIKit
 
-protocol ButtonCellDelegate: AnyObject {
-    func didTapButton()
+protocol UploadButtonCellDelegate: AnyObject {
+    func didTapImageUploadButton()
 }
 
-final class ButtonCell: UICollectionViewCell {
+final class UploadButtonCell: UICollectionViewCell {
     enum Constant {
         static let buttonText = "이미지 업로드"
     }
     
-    weak var delegate: ButtonCellDelegate?
+    weak var delegate: UploadButtonCellDelegate?
     
     private let uploadButton: UIButton = {
         let button = UIButton()
@@ -43,7 +43,7 @@ final class ButtonCell: UICollectionViewCell {
     
     private func configureButtonAction() {
         let buttonAction = UIAction { [weak self] _ in
-            self?.delegate?.didTapButton()
+            self?.delegate?.didTapImageUploadButton()
         }
         
         uploadButton.addAction(buttonAction, for: .touchUpInside)

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
@@ -63,7 +63,7 @@ class ChatInterfaceViewController: MessagesViewController, ButtonCellDelegate {
         }
         
         if case let .custom(item) = message.kind {
-            if item is TagItem {
+            if item is MockTagItem {
                 let cell = messagesCollectionView.dequeueReusableCell(CustomTagContentCell.self, for: indexPath)
                 cell.configure(with: message)
                 return cell
@@ -206,7 +206,7 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
             return MessageSizeCalculator()
         }
         
-        if item is TagItem {
+        if item is MockTagItem {
             return tagMessageCellSizeCalculator
 
         } else if item is [RecommendationItem] {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import MessageKit
 
-class ChatInterfaceViewController: MessagesViewController, ButtonCellDelegate {
+class ChatInterfaceViewController: MessagesViewController {
     enum MessagesDefaultSection: Int {
         case systemMessage = 0
         case uploadButtonMessage = 2
@@ -65,6 +65,7 @@ class ChatInterfaceViewController: MessagesViewController, ButtonCellDelegate {
         if case let .custom(item) = message.kind {
             if item is MockTagItem {
                 let cell = messagesCollectionView.dequeueReusableCell(CustomTagContentCell.self, for: indexPath)
+                cell.delegate = self
                 cell.configure(with: message)
                 return cell
             } else if item is [RecommendationItem] {
@@ -128,6 +129,10 @@ class ChatInterfaceViewController: MessagesViewController, ButtonCellDelegate {
     
     func didTapButton() {
         // [이미지업로드] 버튼 동작을 정의하기위한 메서드, 사용하려는 뷰컨트롤러에서 해당 메서드를 오버라이드하여 사용하세요.
+    }
+    
+    func submitSelectedTags(_ selectedTagList: [MockTag]) {
+        print(selectedTagList)
     }
 }
 
@@ -228,3 +233,5 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
         return nil
     }
 }
+
+extension ChatInterfaceViewController: ButtonCellDelegate, TagSubmissionDelegate { }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
@@ -43,7 +43,7 @@ class ChatInterfaceViewController: MessagesViewController {
             case .systemMessage:
                 return messagesCollectionView.dequeueReusableCell(SystemMessageCell.self, for: indexPath)
             case .uploadButtonMessage:
-                let cell = messagesCollectionView.dequeueReusableCell(ButtonCell.self, for: indexPath)
+                let cell = messagesCollectionView.dequeueReusableCell(UploadButtonCell.self, for: indexPath)
                 cell.delegate = self
                 return cell
             }
@@ -118,7 +118,7 @@ class ChatInterfaceViewController: MessagesViewController {
     
     private func cellResistration() {
         messagesCollectionView.register(SystemMessageCell.self)
-        messagesCollectionView.register(ButtonCell.self)
+        messagesCollectionView.register(UploadButtonCell.self)
         messagesCollectionView.register(CustomTagContentCell.self)
         messagesCollectionView.register(RecommendationCell.self, forCellWithReuseIdentifier: RecommendationCell.identifier)
     }
@@ -127,7 +127,7 @@ class ChatInterfaceViewController: MessagesViewController {
         messagesCollectionView.backgroundColor = .blueGrayBackground
     }
     
-    func didTapButton() {
+    func didTapImageUploadButton() {
         // [이미지업로드] 버튼 동작을 정의하기위한 메서드, 사용하려는 뷰컨트롤러에서 해당 메서드를 오버라이드하여 사용하세요.
     }
     
@@ -234,4 +234,4 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
     }
 }
 
-extension ChatInterfaceViewController: ButtonCellDelegate, TagSubmissionDelegate { }
+extension ChatInterfaceViewController: UploadButtonCellDelegate, TagSubmissionDelegate { }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatViewController.swift
@@ -44,7 +44,7 @@ final class ChatViewController: ChatInterfaceViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func didTapButton() {
+    override func didTapImageUploadButton() {
         presentPHPicekrViewController()
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatViewController.swift
@@ -16,12 +16,13 @@ final class ChatViewController: ChatInterfaceViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigation()
-        let message = Message(tags: [Tag(text: "아라"),
-                                     Tag(text: "아라아"),
-                                     Tag(text: "아라아라"),
-                                     Tag(text: "아라아라아"),
-                                     Tag(text: "아라아라아라")
-                                    ])
+        let message = Message(mockTags: [
+            MockTag(category: .theme, text: "안녕"),
+            MockTag(category: .theme, text: "하용"),
+            MockTag(category: .theme, text: "하히"),
+            MockTag(category: .theme, text: "하이2"),
+            MockTag(category: .theme, text: "ㅎ2"),
+        ])
         messageStorage.insertMessage(message)
                               
         var recommendations: [RecommendationItem] = []

--- a/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
@@ -46,7 +46,7 @@ final class CustomTagContentCellViewModel {
     }
     
     func updateTagIsSelected(value: String, isSelected: Bool) {
-        tagStorage.updateTagIsSelected(value: value, isSelected: isSelected)
+        tagStorage.updateTagSelectionState(value: value, isSelected: isSelected)
     }
     
     func cellSizeForSection(indexPath: IndexPath) -> CGSize {

--- a/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
@@ -11,19 +11,19 @@ final class CustomTagContentCellViewModel {
     private let tagStorage: TagStorage = TagStorage()
     
     var locationTagListCount: Int {
-        return tagStorage.locationTagList.count
+        return tagStorage.locationTags.count
     }
     
     var themeTagListCount: Int {
-        return tagStorage.themeTagList.count
+        return tagStorage.themeTags.count
     }
     
     var locationTagList: [MockTag] {
-        return tagStorage.locationTagList
+        return tagStorage.locationTags
     }
     
     var themeTagList: [MockTag] {
-        return tagStorage.themeTagList
+        return tagStorage.themeTags
     }
     
     var sectionsHeaderTexts: [String] {
@@ -52,11 +52,11 @@ final class CustomTagContentCellViewModel {
     func cellSizeForSection(indexPath: IndexPath) -> CGSize {
         switch indexPath.section {
         case 0:
-            let numberofCharactoersInTag = CGFloat(tagStorage.locationTagList[indexPath.item].text.count)
+            let numberofCharactoersInTag = CGFloat(tagStorage.locationTags[indexPath.item].text.count)
             
             return calculateSizeForCharacters(count: numberofCharactoersInTag)
         case 1:
-            let numberOfCharactersInTag = CGFloat(tagStorage.themeTagList[indexPath.item].text.count)
+            let numberOfCharactersInTag = CGFloat(tagStorage.themeTags[indexPath.item].text.count)
             
             return calculateSizeForCharacters(count: numberOfCharactersInTag)
         default:

--- a/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
@@ -1,0 +1,81 @@
+//
+//  CustomTagContentCellViewModel.swift
+//  TravelGenie
+//
+//  Created by 서현웅 on 2023/08/25.
+//
+
+import Foundation
+
+final class CustomTagContentCellViewModel {
+    private let tagStorage: TagStorage = TagStorage()
+    
+    var locationTagListCount: Int {
+        return tagStorage.locationTagList.count
+    }
+    
+    var themeTagListCount: Int {
+        return tagStorage.themeTagList.count
+    }
+    
+    var locationTagList: [MockTag] {
+        return tagStorage.locationTagList
+    }
+    
+    var themeTagList: [MockTag] {
+        return tagStorage.themeTagList
+    }
+    
+    var sectionsHeaderTexts: [String] {
+        return ["✈️지역", "⛵️테마"]
+    }
+    
+    // MARK: Internal
+    
+    func insertTags(tags: [MockTag]) {
+        tagStorage.insertTags(tags: tags)
+    }
+    
+    func getSelectedTags() -> [MockTag]? {
+        guard let isSelectedTags = tagStorage.getSelectedTags() else {
+            print("선택된 태그없음")
+            return nil
+        }
+        
+        return isSelectedTags
+    }
+    
+    func updateTagIsSelected(value: String, isSelected: Bool) {
+        tagStorage.updateTagIsSelected(value: value, isSelected: isSelected)
+    }
+    
+    func cellSizeForSection(indexPath: IndexPath) -> CGSize {
+        switch indexPath.section {
+        case 0:
+            let numberofCharactoersInTag = CGFloat(tagStorage.locationTagList[indexPath.item].text.count)
+            
+            return calculateSizeForCharacters(count: numberofCharactoersInTag)
+        case 1:
+            let numberOfCharactersInTag = CGFloat(tagStorage.themeTagList[indexPath.item].text.count)
+            
+            return calculateSizeForCharacters(count: numberOfCharactersInTag)
+        default:
+            break
+        }
+        
+        return CGSize(width: 0, height: 0)
+    }
+    
+    // MARK: Private
+    
+    private func calculateSizeForCharacters(count: CGFloat) -> CGSize {
+        let additionalWidthForOneCharacterSize: CGFloat = 13.0
+        let defaultHeight: CGFloat = 47.0
+        let defaultWidth: CGFloat = 48.0
+        
+        let widthResult = defaultWidth + (count * additionalWidthForOneCharacterSize)
+
+        return CGSize(width: widthResult, height: defaultHeight)
+    }   
+}
+

--- a/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/CustomTagContentCellViewModel.swift
@@ -33,7 +33,7 @@ final class CustomTagContentCellViewModel {
     // MARK: Internal
     
     func insertTags(tags: [MockTag]) {
-        tagStorage.insertTags(tags: tags)
+        tagStorage.insertTags(tags)
     }
     
     func getSelectedTags() -> [MockTag]? {


### PR DESCRIPTION
**TagCell Submit 로직 관련**

- 순서: TagCollectionViewCell -> TagContentCell -> ChatInterfaceViewController -> ChatViewController
- 순서에 맞도록 [선택 -> 제출 -> 수신 -> 오버라이드] 가능하도록 구현해두었습니다. 
- ChatViewController에서 제출한 태그를 활용하여 ChatGPT에 요청하는 작업을 진행하면 될 것 같습니다

**MockTag 객체 관련**
- 현재, Domain Entity 작업이 많다고 하셔서 Tag 프로퍼티의 일부 속성을 수정하여야 할 일을 MockTag, MockTagItem으로 구현해두었습니다.
- 이 사항은 섬캣의 Entity 작업이 끝나고 제 PR도 머지된 다음 새로 커밋을 쳐서 올리겠습니다. 
(MockTag가 적용된 영역은 Presentation-View-Chat 부분입니다~)