### PR TITLE
Feature/18/TagCell SizeCalculator 리팩토링

### DIFF
--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -155,7 +155,7 @@ final class CustomTagContentCell: UICollectionViewCell {
         
         submitKeywordButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            submitKeywordButton.topAnchor.constraint(equalTo: tagCollectionView.bottomAnchor, constant: 12),
+            submitKeywordButton.topAnchor.constraint(equalTo: tagCollectionView.bottomAnchor),
             submitKeywordButton.leadingAnchor.constraint(equalTo: messageContentView.leadingAnchor, constant: 20),
             submitKeywordButton.trailingAnchor.constraint(equalTo: messageContentView.trailingAnchor, constant: -20),
             submitKeywordButton.bottomAnchor.constraint(equalTo: messageContentView.bottomAnchor, constant: -12)
@@ -240,7 +240,7 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         referenceSizeForHeaderInSection section: Int)
         -> CGSize
     {
-        return CGSize(width: 240, height: 23)
+        return CGSize(width: 204, height: 23)
     }
     
     func collectionView(
@@ -249,7 +249,7 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         insetForSectionAt section: Int)
         -> UIEdgeInsets
     {
-        return UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
+        return UIEdgeInsets(top: 4, left: 0, bottom: 12, right: 0)
     }
     
     func collectionView(
@@ -278,9 +278,8 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         let messageLabelHeight = defaultMessageLabel.frame.height
         let tagCollectionViewContentHeight = tagCollectionViewLayout.totalHeight
         let submitKeywordButtonHeight = submitKeywordButton.frame.height
-        let insetPadding: CGFloat = 20
         
-        return tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight + insetPadding
+        return tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -12,8 +12,13 @@ protocol TagSubmissionDelegate: AnyObject {
     func submitSelectedTags(_ selectedTags: [Tag])
 }
 
+protocol TagMessageSizeDelegate: AnyObject {
+    func didUpdateTagMessageHeight(_ height: CGFloat)
+}
+
 final class CustomTagContentCell: UICollectionViewCell {
     weak var delegate: TagSubmissionDelegate?
+    weak var sizedelegate: TagMessageSizeDelegate? // 위 delegate 변수가 NotificationCenter로 변경되면서 제거될 예정이므로 이를 sizedelegate로 지어뒀지만, PR 이 후, delegate로 수정하려고합니다.
     
     private let viewModel = CustomTagContentCellViewModel()
     
@@ -261,6 +266,7 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         // messageContainerHeightLayoutConstraint.constant가 contentsSize를 반영하지 않은 경우에만 업데이트
         if messageContentViewHeightLayoutConstraint?.constant != totalContentHeight {
             messageContentViewHeightLayoutConstraint?.constant = totalContentHeight
+            sizedelegate?.didUpdateTagMessageHeight(totalContentHeight)
         }
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -254,6 +254,15 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
     
     func collectionView(
         _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumLineSpacingForSectionAt section: Int)
+        -> CGFloat
+    {
+        return 8
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
         willDisplay cell: UICollectionViewCell,
         forItemAt indexPath: IndexPath)
     {

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -252,10 +252,19 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         willDisplay cell: UICollectionViewCell,
         forItemAt indexPath: IndexPath)
     {
-        updateCollectionViewHeight(tagCollectionView)
+        updateCollectionViewHeight()
     }
     
-    private func updateCollectionViewHeight(_ collectionView: UICollectionView) {
+    private func updateCollectionViewHeight() {
+        let totalContentHeight = totalContentHeight(tagCollectionView)
+        
+        // messageContainerHeightLayoutConstraint.constant가 contentsSize를 반영하지 않은 경우에만 업데이트
+        if messageContentViewHeightLayoutConstraint?.constant != totalContentHeight {
+            messageContentViewHeightLayoutConstraint?.constant = totalContentHeight
+        }
+    }
+    
+    private func totalContentHeight(_ collectionView: UICollectionView) -> CGFloat {
         guard let tagCollectionViewLayout = collectionView.collectionViewLayout as? LeftAlignedCollectionViewFlowLayout else {
             fatalError("flowLayout Error")
         }
@@ -264,12 +273,8 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         let tagCollectionViewContentHeight = tagCollectionViewLayout.totalHeight
         let submitKeywordButtonHeight = submitKeywordButton.frame.height
         let insetPadding: CGFloat = 20
-        let totalContentHeight = tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight + insetPadding
         
-        // messageContainerHeightLayoutConstraint.constant가 contentsSize를 반영하지 않은 경우에만 업데이트
-        if messageContentViewHeightLayoutConstraint?.constant != totalContentHeight {
-            messageContentViewHeightLayoutConstraint?.constant = totalContentHeight
-        }
+        return tagCollectionViewContentHeight + messageLabelHeight + submitKeywordButtonHeight + insetPadding
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/SizeCalculator/TagMessageCellSizeCalculator.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/Cell/CustomTagCell/SizeCalculator/TagMessageCellSizeCalculator.swift
@@ -10,8 +10,14 @@ import UIKit
 
 final class TagMessageCellSizeCalculator: CustomCellSizeCalculator {
     
+    private var dynamicHeight: CGFloat = .zero
+    
     override func messageContainerSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
-        return CGSize(width: .zero, height: 500)
+        return CGSize(width: .zero, height: dynamicHeight)
+    }
+    
+    func updateMessageContainerHeight(_ height: CGFloat) {
+        dynamicHeight = height
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
@@ -244,6 +244,12 @@ extension ChatInterfaceViewController: UploadButtonCellDelegate, TagSubmissionDe
 
 extension ChatInterfaceViewController: TagMessageSizeDelegate {
     func didUpdateTagMessageHeight(_ height: CGFloat) {
-        print("안녕델리게이트")   
+        let tagCellIndex: IndexSet = IndexSet(integer: 3)
+        
+        tagMessageCellSizeCalculator.updateMessageContainerHeight(height)
+        
+        UIView.performWithoutAnimation {
+            messagesCollectionView.reloadSections(tagCellIndex)
+        }
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
@@ -66,6 +66,7 @@ class ChatInterfaceViewController: MessagesViewController {
             if item is TagItem {
                 let cell = messagesCollectionView.dequeueReusableCell(CustomTagContentCell.self, for: indexPath)
                 cell.delegate = self
+                cell.sizedelegate = self
                 cell.configure(with: message)
                 return cell
             } else if item is [RecommendationItem] {
@@ -240,3 +241,9 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
 }
 
 extension ChatInterfaceViewController: UploadButtonCellDelegate, TagSubmissionDelegate { }
+
+extension ChatInterfaceViewController: TagMessageSizeDelegate {
+    func didUpdateTagMessageHeight(_ height: CGFloat) {
+        print("안녕델리게이트")   
+    }
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatInterface/ChatInterfaceViewController.swift
@@ -220,8 +220,13 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
         
         return MessageSizeCalculator()
     }
-    
-    func textCellSizeCalculator(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator? {
+        
+    func attributedTextCellSizeCalculator(
+        for message: MessageType,
+        at indexPath: IndexPath,
+        in messagesCollectionView: MessagesCollectionView)
+        -> CellSizeCalculator?
+    {
         if let defaultSection = MessagesDefaultSection(rawValue: indexPath.section) {
             switch defaultSection {
             case .systemMessage:


### PR DESCRIPTION
**TagSizeCalculator Self-Sizing 관련**
- TagCell의 컨텐츠 사이즈에 따라 메시지컬렉션뷰의 해당섹션의 높이가 변경될 수 있도록 구현하였습니다.

**세부 적용 내용**
- TagContentCell에 기존에 사이즈를 계산하던 내부 함수를 통해 얻은 값으로
- SizeCalculator의 변수에 전달합니다.
- 전달한 값으로 해당 섹션을 reload하여 계산된 셀의 높이를 적용합니다.

++
UploadButtonCell, SystemMessageCell은 일단 상수로 적용해뒀습니다.
Chat이 작동하는 로직(정확히 사진 및 번역 API등의 적용) 이 우선순위가 높은 것 같아 해당 작업을 우선으로 진행해보겠습니다