### PR TITLE
Refactor/19/ChatScene 리팩토링

### DIFF
--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		5763DEFD2A99B81F0028B19F /* PopUpContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEFC2A99B81F0028B19F /* PopUpContentView.swift */; };
 		5763DEFF2A99B9300028B19F /* PopUpModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEFE2A99B9300028B19F /* PopUpModel.swift */; };
 		5763DF072A9CA8020028B19F /* ChatInterfaceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DF062A9CA8020028B19F /* ChatInterfaceViewModel.swift */; };
+		5763DF092A9CAF220028B19F /* NotificationName+swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DF082A9CAF220028B19F /* NotificationName+swift.swift */; };
 		57684BF92A73CAFE008AB8C9 /* OpenAIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57684BF82A73CAFE008AB8C9 /* OpenAIRepository.swift */; };
 		576EC3A92A9742DC008C2D7C /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EC3A82A9742DC008C2D7C /* SearchBarView.swift */; };
 		576EC3AE2A978077008C2D7C /* TextAttributeCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EC3AD2A978077008C2D7C /* TextAttributeCreator.swift */; };
@@ -158,6 +159,7 @@
 		5763DEFC2A99B81F0028B19F /* PopUpContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpContentView.swift; sourceTree = "<group>"; };
 		5763DEFE2A99B9300028B19F /* PopUpModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpModel.swift; sourceTree = "<group>"; };
 		5763DF062A9CA8020028B19F /* ChatInterfaceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInterfaceViewModel.swift; sourceTree = "<group>"; };
+		5763DF082A9CAF220028B19F /* NotificationName+swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+swift.swift"; sourceTree = "<group>"; };
 		57684BF82A73CAFE008AB8C9 /* OpenAIRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRepository.swift; sourceTree = "<group>"; };
 		576EC3A82A9742DC008C2D7C /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		576EC3AD2A978077008C2D7C /* TextAttributeCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributeCreator.swift; sourceTree = "<group>"; };
@@ -418,6 +420,7 @@
 				576EC3AD2A978077008C2D7C /* TextAttributeCreator.swift */,
 				576EC3B22A97B39F008C2D7C /* CircleIconView.swift */,
 				576EC3B42A97BE8F008C2D7C /* RectangleTextButton.swift */,
+				5763DF082A9CAF220028B19F /* NotificationName+swift.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -838,6 +841,7 @@
 				D2E3AA262A8B62320049DDEF /* ChatViewController.swift in Sources */,
 				57462B4B2A95B5ED00949D5C /* ChatRepository.swift in Sources */,
 				D2F8C5872A8F6E2700AA3BFC /* TagCollectionViewCell.swift in Sources */,
+				5763DF092A9CAF220028B19F /* NotificationName+swift.swift in Sources */,
 				57462B792A96302C00949D5C /* RecommendationEntity+CoreDataProperties.swift in Sources */,
 				573BCD5A2A925C2F00116D2D /* ChatListViewModel.swift in Sources */,
 				D20FA2752A6B8DA90081B039 /* SceneDelegate.swift in Sources */,

--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		5763DEF72A991D560028B19F /* UserFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEF62A991D560028B19F /* UserFeedback.swift */; };
 		5763DEFD2A99B81F0028B19F /* PopUpContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEFC2A99B81F0028B19F /* PopUpContentView.swift */; };
 		5763DEFF2A99B9300028B19F /* PopUpModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DEFE2A99B9300028B19F /* PopUpModel.swift */; };
+		5763DF072A9CA8020028B19F /* ChatInterfaceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5763DF062A9CA8020028B19F /* ChatInterfaceViewModel.swift */; };
 		57684BF92A73CAFE008AB8C9 /* OpenAIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57684BF82A73CAFE008AB8C9 /* OpenAIRepository.swift */; };
 		576EC3A92A9742DC008C2D7C /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EC3A82A9742DC008C2D7C /* SearchBarView.swift */; };
 		576EC3AE2A978077008C2D7C /* TextAttributeCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576EC3AD2A978077008C2D7C /* TextAttributeCreator.swift */; };
@@ -156,6 +157,7 @@
 		5763DEF62A991D560028B19F /* UserFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedback.swift; sourceTree = "<group>"; };
 		5763DEFC2A99B81F0028B19F /* PopUpContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpContentView.swift; sourceTree = "<group>"; };
 		5763DEFE2A99B9300028B19F /* PopUpModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpModel.swift; sourceTree = "<group>"; };
+		5763DF062A9CA8020028B19F /* ChatInterfaceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInterfaceViewModel.swift; sourceTree = "<group>"; };
 		57684BF82A73CAFE008AB8C9 /* OpenAIRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRepository.swift; sourceTree = "<group>"; };
 		576EC3A82A9742DC008C2D7C /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		576EC3AD2A978077008C2D7C /* TextAttributeCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttributeCreator.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				573BCD472A92146F00116D2D /* RecommendationCellViewModel.swift */,
 				D24DF9C52A9876620066C5B3 /* CustomTagContentCellViewModel.swift */,
 				D2E3AA272A8B62400049DDEF /* ChatViewModel.swift */,
+				5763DF062A9CA8020028B19F /* ChatInterfaceViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -774,6 +777,7 @@
 				D20FA2732A6B8DA90081B039 /* AppDelegate.swift in Sources */,
 				576EC3B52A97BE8F008C2D7C /* RectangleTextButton.swift in Sources */,
 				D2E81B8A2A9116F6006A5236 /* ContentItem.swift in Sources */,
+				5763DF072A9CA8020028B19F /* ChatInterfaceViewModel.swift in Sources */,
 				573BCD042A8BAF7600116D2D /* HomeViewController.swift in Sources */,
 				D2833A302A8E1578000FEE30 /* MessageStorage.swift in Sources */,
 				D2E3AA332A8B83520049DDEF /* ChatInterfaceViewController.swift in Sources */,

--- a/TravelGenie/TravelGenie/Domain/Entity/ContentItem.swift
+++ b/TravelGenie/TravelGenie/Domain/Entity/ContentItem.swift
@@ -25,9 +25,11 @@ struct ImageMediaItem: MediaItem {
         if image == nil, imageData != nil {
             let imageFromData = UIImage(data: imageData!)
             self.image = imageFromData
+            self.imageData = imageData
             size = imageFromData?.size ?? .init()
         } else if image != nil, imageData == nil {
             let dataFromImage = image?.pngData()
+            self.image = image
             self.imageData = dataFromImage
             size = image!.size
         } else {

--- a/TravelGenie/TravelGenie/Domain/Model/MessageStorage.swift
+++ b/TravelGenie/TravelGenie/Domain/Model/MessageStorage.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class MessageStorage {
+    
     enum Constant {
         static let welcomeText = "오늘은 어디로 여행을 떠나고 싶나요? 사진을 보내주시면 원하는 분위기의 여행지를 추천해드릴게요!"
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -8,10 +8,6 @@
 import UIKit
 import MessageKit
 
-protocol TagSubmissionDelegate: AnyObject {
-    func submitSelectedTags(_ selectedTags: [Tag])
-}
-
 final class CustomTagContentCell: UICollectionViewCell {
     
     private let viewModel = CustomTagContentCellViewModel()

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -19,6 +19,8 @@ final class CustomTagContentCell: UICollectionViewCell {
     private let submitKeywordButton = UIButton()
     private var messageContentViewHeightLayoutConstraint: NSLayoutConstraint?
     
+    // MARK: Lifecycle
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureSubviews()
@@ -30,6 +32,8 @@ final class CustomTagContentCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: Internal
+    
     func configure(with message: MessageType) {
         if case .custom(let tagItem) = message.kind {
             guard let tagItem = tagItem as? TagItem else { return }
@@ -37,6 +41,8 @@ final class CustomTagContentCell: UICollectionViewCell {
             viewModel.insertTags(tags: tagItem.tags)
         }
     }
+    
+    // MARK: Private
     
     private func configureSubviews() {
         configureSubmitKeywordButton()
@@ -152,6 +158,8 @@ final class CustomTagContentCell: UICollectionViewCell {
     }
 }
 
+// MARK: UICollectionViewDataSource
+
 extension CustomTagContentCell: UICollectionViewDataSource {
     fileprivate enum Section: Int {
         case location
@@ -213,6 +221,8 @@ extension CustomTagContentCell: UICollectionViewDataSource {
     }
 }
 
+// MARK: UICollectionViewDelegateFlowLayout
+
 extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
     func collectionView(
         _ collectionView: UICollectionView,
@@ -266,6 +276,8 @@ extension CustomTagContentCell: UICollectionViewDelegateFlowLayout {
         }
     }
 }
+
+// MARK: TagSelectionDelegate
 
 extension CustomTagContentCell: TagSelectionDelegate {
     func tagDidSelect(withText value: String, isSelected: Bool) {

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/CustomTagContentCell.swift
@@ -13,7 +13,6 @@ protocol TagSubmissionDelegate: AnyObject {
 }
 
 final class CustomTagContentCell: UICollectionViewCell {
-    weak var delegate: TagSubmissionDelegate?
     
     private let viewModel = CustomTagContentCellViewModel()
     
@@ -103,9 +102,8 @@ final class CustomTagContentCell: UICollectionViewCell {
                 return
             }
             
-            self.delegate?.submitSelectedTags(selectedList)
+            self.viewModel.submitSelectedTags(selectedList)
         }
-        
         submitKeywordButton.addAction(buttonAction, for: .touchUpInside)
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/SizeCalculator/CustomCellSizeCalculator.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/SizeCalculator/CustomCellSizeCalculator.swift
@@ -30,6 +30,8 @@ class CustomCellSizeCalculator: CellSizeCalculator {
         self.messagesLayout.messagesDataSource
     }
     
+    // MARK: Override(s)
+    
     override func sizeForItem(at indexPath: IndexPath) -> CGSize {
         let dataSource = messagesDataSource
         let message = dataSource.messageForItem(at: indexPath, in: messagesLayout.messagesCollectionView)

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagStorage.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagStorage.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 final class TagStorage {
-    private var tags = [Tag]()
     
     var count: Int {
         return tags.count
@@ -22,13 +21,18 @@ final class TagStorage {
         return tags.filter { $0.category == .theme }
     }
     
+    private var tags = [Tag]()
     private var selectedTags: [Tag] {
         return tags.filter { $0.isSelected == true }
     }
     
+    // MARK: Lifecycle
+    
     init() {
         tags = setDefaultTags()
     }
+    
+    // MARK: Internal
     
     func getSelectedTags() -> [Tag]? {
         return selectedTags.isEmpty ? nil : selectedTags
@@ -44,11 +48,12 @@ final class TagStorage {
         }
     }
     
+    // MARK: Private
+    
     private func setDefaultTags() -> [Tag] {
         let defaultTag = [
             Tag(category: .location, value: "국내"),
-            Tag(category: .location, value: "해외")
-        ]
+            Tag(category: .location, value: "해외")]
         
         return defaultTag
     }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/LeftAlignedCollectionViewFlowLayout.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/LeftAlignedCollectionViewFlowLayout.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
+    
     let customMinimumInteritemSpacingForSectionAt: CGFloat = 8
     var totalHeight: CGFloat = 0 // 셀과 헤더 전체 높이를 계산하기 위한 변수
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/TagCollectionHeaderView.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/TagCollectionHeaderView.swift
@@ -11,12 +11,13 @@ class TagCollectionHeaderView: UICollectionReusableView {
     static var identifier: String { return String(describing: self) }
     
     private let titleLabel: UILabel = {
-       let label = UILabel()
-        
+        let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
     }()
+    
+    // MARK: Lifecycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -26,11 +27,15 @@ class TagCollectionHeaderView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: Internal
 
     func configure(text: String) {
         titleLabel.attributedText = NSMutableAttributedString()
             .text(text, font: .bodyRegular, color: .black)
     }
+    
+    // MARK: Private
     
     private func configureLayout() {
         self.addSubview(titleLabel)

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/CustomTagCell/TagView/TagCollectionViewCell.swift
@@ -12,10 +12,14 @@ protocol TagSelectionDelegate: AnyObject {
 }
 
 class TagCollectionViewCell: UICollectionViewCell {
+    
     static var identifier: String { return String(describing: self) }
     
     weak var delegate: TagSelectionDelegate?
+    
     private let tagButton: UIButton = UIButton()
+    
+    // MARK: Lifecycle
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
@@ -27,9 +31,13 @@ class TagCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: Internal
+    
     func configure(tag: Tag) {
         configureTagButtonText(tag: tag)
     }
+    
+    // MARK: Private
     
     private func configureSubviews() {
         congirueTagButton()

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/SystemMessageCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/SystemMessageCell.swift
@@ -9,11 +9,16 @@ import MessageKit
 import UIKit
 
 final class SystemMessageCell: UICollectionViewCell {
+    
     enum Constant {
-        static let welcomeText = "입력 데이터는 OpenAI의 데이터 사용 정책과 XXX의 개인정보 처리방침에 따라 관리됩니다. 이 서비스는 초기버전으로 AI 답변의 신뢰성과 사용 시 생기는 문제에 책임을 지지 않으며 사정에 따라 사전 안내없이 중단 할 수 있습니다. 개인 정보를 입력하지 않도록 유의해 주세요."
+        static let welcomeText = """
+            입력 데이터는 OpenAI의 데이터 사용 정책과 XXX의 개인정보 처리방침에 따라 관리됩니다. 이 서비스는 초기버전으로 AI 답변의 신뢰성과 사용 시 생기는 문제에 책임을 지지 않으며 사정에 따라 사전 안내없이 중단 할 수 있습니다. 개인 정보를 입력하지 않도록 유의해 주세요.
+            """
     }
     
     private let welcomeMessageTextView = UITextView()
+    
+    // MARK: Lifecycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -24,6 +29,8 @@ final class SystemMessageCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: Private
     
     private func configureWelcomeMessageTextView() {
         welcomeMessageTextView.backgroundColor = .blueGrayBackground

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
@@ -13,25 +13,16 @@ final class UploadButtonCell: UICollectionViewCell {
         static let buttonText = "이미지 업로드"
     }
     
-    private let uploadButton: UIButton = {
-        let button = UIButton()
-        
-        button.setTitle(Constant.buttonText, for: .normal)
-        button.setTitleColor(UIColor.white, for: .normal)
-        button.backgroundColor = .primary
-        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
-        button.layer.cornerRadius = 10
-        button.translatesAutoresizingMaskIntoConstraints = false
-        
-        return button
-    }()
+    private let uploadButton = RectangleTextButton()
+        .backgroundColor(.primary)
+        .cornerRadius(12)
     
     // MARK: Lifecycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureUploadButton()
         configureLayout()
-        configureButtonAction()
     }
     
     required init?(coder: NSCoder) {
@@ -39,6 +30,13 @@ final class UploadButtonCell: UICollectionViewCell {
     }
     
     // MARK: Private
+    
+    private func configureUploadButton() {
+        let buttonTitle = NSMutableAttributedString()
+            .text(Constant.buttonText, font: .headline, color: .white)
+        uploadButton.setAttributedTitle(buttonTitle, for: .normal)
+        configureButtonAction()
+    }
     
     private func configureButtonAction() {
         let buttonAction = UIAction { _ in
@@ -51,6 +49,7 @@ final class UploadButtonCell: UICollectionViewCell {
     private func configureLayout() {
         contentView.addSubview(uploadButton)
         
+        uploadButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             uploadButton.widthAnchor.constraint(equalToConstant: 351),
             uploadButton.heightAnchor.constraint(equalToConstant: 58),

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 final class UploadButtonCell: UICollectionViewCell {
-    enum Constant {
+    
+    private enum Constant {
         static let buttonText = "이미지 업로드"
     }
     
@@ -25,6 +26,8 @@ final class UploadButtonCell: UICollectionViewCell {
         return button
     }()
     
+    // MARK: Lifecycle
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureLayout()
@@ -34,6 +37,8 @@ final class UploadButtonCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: Private
     
     private func configureButtonAction() {
         let buttonAction = UIAction { _ in

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/DefaultSystemSectionCell/UploadButtonCell.swift
@@ -7,16 +7,10 @@
 
 import UIKit
 
-protocol UploadButtonCellDelegate: AnyObject {
-    func didTapImageUploadButton()
-}
-
 final class UploadButtonCell: UICollectionViewCell {
     enum Constant {
         static let buttonText = "이미지 업로드"
     }
-    
-    weak var delegate: UploadButtonCellDelegate?
     
     private let uploadButton: UIButton = {
         let button = UIButton()
@@ -42,8 +36,8 @@ final class UploadButtonCell: UICollectionViewCell {
     }
     
     private func configureButtonAction() {
-        let buttonAction = UIAction { [weak self] _ in
-            self?.delegate?.didTapImageUploadButton()
+        let buttonAction = UIAction { _ in
+            NotificationCenter.default.post(name: .imageUploadButtonTapped, object: nil)
         }
         
         uploadButton.addAction(buttonAction, for: .touchUpInside)

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/RecommendationCell/RecommendationCell.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/Cell/RecommendationCell/RecommendationCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class RecommendationCell: UICollectionViewCell {
     
-    enum Design {
+    private enum Design {
         static let leftPadding: CGFloat = 12
         static let avatarViewSize: CGFloat = 40
         static let spacing: CGFloat = 8

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -15,7 +15,8 @@ class ChatInterfaceViewController: MessagesViewController {
     }
 
     let defaultSender: Sender = Sender(name: .user)
-    var messageStorage: MessageStorage = MessageStorage()
+    let chatInterfaceViewModel = ChatInterfaceViewModel()
+
     private lazy var tagMessageCellSizeCalculator
     = TagMessageCellSizeCalculator(layout: self.messagesCollectionView.messagesCollectionViewFlowLayout)
     private lazy var recommendationCellSizeCalculator
@@ -44,7 +45,6 @@ class ChatInterfaceViewController: MessagesViewController {
                 return messagesCollectionView.dequeueReusableCell(SystemMessageCell.self, for: indexPath)
             case .uploadButtonMessage:
                 let cell = messagesCollectionView.dequeueReusableCell(UploadButtonCell.self, for: indexPath)
-                cell.delegate = self
                 return cell
             }
         }
@@ -78,7 +78,7 @@ class ChatInterfaceViewController: MessagesViewController {
     }
     
     private func bind() {
-        messageStorage.didChangedMessageList = { [weak self] in
+        chatInterfaceViewModel.messageStorage.didChangedMessageList = { [weak self] in
             self?.messagesCollectionView.reloadData()
         }
     }
@@ -141,11 +141,11 @@ extension ChatInterfaceViewController: MessagesDataSource {
     }
     
     func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
-        return messageStorage.sectionOfMessageList(indexPath.section)
+        return chatInterfaceViewModel.messageStorage.sectionOfMessageList(indexPath.section)
     }
     
     func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
-        return messageStorage.count
+        return chatInterfaceViewModel.messageStorage.count
     }
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -136,14 +136,6 @@ class ChatInterfaceViewController: MessagesViewController {
     private func configureMessagesCollectionViewBackgroundColor() {
         messagesCollectionView.backgroundColor = .blueGrayBackground
     }
-    
-    func didTapImageUploadButton() {
-        // [이미지업로드] 버튼 동작을 정의하기위한 메서드, 사용하려는 뷰컨트롤러에서 해당 메서드를 오버라이드하여 사용하세요.
-    }
-    
-    func submitSelectedTags(_ selectedTags: [Tag]) {
-        print(selectedTags)
-    }
 }
 
 // MARK: MessagesDataSource

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -232,5 +232,3 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
         return nil
     }
 }
-
-extension ChatInterfaceViewController: UploadButtonCellDelegate { }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import MessageKit
 
 class ChatInterfaceViewController: MessagesViewController {
+    
     enum MessagesDefaultSection: Int {
         case systemMessage = 0
         case uploadButtonMessage = 2
@@ -18,9 +19,11 @@ class ChatInterfaceViewController: MessagesViewController {
     let chatInterfaceViewModel = ChatInterfaceViewModel()
 
     private lazy var tagMessageCellSizeCalculator
-    = TagMessageCellSizeCalculator(layout: self.messagesCollectionView.messagesCollectionViewFlowLayout)
+        = TagMessageCellSizeCalculator(layout: self.messagesCollectionView.messagesCollectionViewFlowLayout)
     private lazy var recommendationCellSizeCalculator
-    = RecommendationCellSizeCalculator(layout: self.messagesCollectionView.messagesCollectionViewFlowLayout)
+        = RecommendationCellSizeCalculator(layout: self.messagesCollectionView.messagesCollectionViewFlowLayout)
+    
+    // MARK: Override(s)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,7 +31,11 @@ class ChatInterfaceViewController: MessagesViewController {
         setupMessagesCollectionViewAttributes()
     }
     
-    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    override func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath)
+        -> UICollectionViewCell
+    {
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
             fatalError("Datasource error")
         }
@@ -51,6 +58,8 @@ class ChatInterfaceViewController: MessagesViewController {
 
         return super.collectionView(collectionView, cellForItemAt: indexPath)
     }
+    
+    // MARK: Internal
     
     func customCell(
         for message: MessageType,
@@ -119,7 +128,9 @@ class ChatInterfaceViewController: MessagesViewController {
         messagesCollectionView.register(SystemMessageCell.self)
         messagesCollectionView.register(UploadButtonCell.self)
         messagesCollectionView.register(CustomTagContentCell.self)
-        messagesCollectionView.register(RecommendationCell.self, forCellWithReuseIdentifier: RecommendationCell.identifier)
+        messagesCollectionView.register(
+            RecommendationCell.self,
+            forCellWithReuseIdentifier: RecommendationCell.identifier)
     }
     
     private func configureMessagesCollectionViewBackgroundColor() {
@@ -135,12 +146,18 @@ class ChatInterfaceViewController: MessagesViewController {
     }
 }
 
+// MARK: MessagesDataSource
+
 extension ChatInterfaceViewController: MessagesDataSource {
     var currentSender: SenderType {
         return defaultSender
     }
     
-    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+    func messageForItem(
+        at indexPath: IndexPath,
+        in messagesCollectionView: MessagesCollectionView)
+        -> MessageType
+    {
         return chatInterfaceViewModel.messageStorage.sectionOfMessageList(indexPath.section)
     }
     
@@ -148,6 +165,8 @@ extension ChatInterfaceViewController: MessagesDataSource {
         return chatInterfaceViewModel.messageStorage.count
     }
 }
+
+// MARK: MessagesDisplayDelegate
 
 extension ChatInterfaceViewController: MessagesDisplayDelegate {
     func textColor(
@@ -199,6 +218,8 @@ extension ChatInterfaceViewController: MessagesDisplayDelegate {
     }
 }
 
+// MARK: MessagesLayoutDelegate
+
 extension ChatInterfaceViewController: MessagesLayoutDelegate {
     func customCellSizeCalculator(
         for message: MessageType,
@@ -220,7 +241,12 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
         return MessageSizeCalculator()
     }
     
-    func textCellSizeCalculator(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator? {
+    func textCellSizeCalculator(
+        for message: MessageType,
+        at indexPath: IndexPath,
+        in messagesCollectionView: MessagesCollectionView)
+        -> CellSizeCalculator?
+    {
         if let defaultSection = MessagesDefaultSection(rawValue: indexPath.section) {
             switch defaultSection {
             case .systemMessage:

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatInterface/ChatInterfaceViewController.swift
@@ -65,7 +65,6 @@ class ChatInterfaceViewController: MessagesViewController {
         if case let .custom(item) = message.kind {
             if item is TagItem {
                 let cell = messagesCollectionView.dequeueReusableCell(CustomTagContentCell.self, for: indexPath)
-                cell.delegate = self
                 cell.configure(with: message)
                 return cell
             } else if item is [RecommendationItem] {
@@ -234,4 +233,4 @@ extension ChatInterfaceViewController: MessagesLayoutDelegate {
     }
 }
 
-extension ChatInterfaceViewController: UploadButtonCellDelegate, TagSubmissionDelegate { }
+extension ChatInterfaceViewController: UploadButtonCellDelegate { }

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -26,6 +26,8 @@ final class ChatViewController: ChatInterfaceViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: Override(s)
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigation()
@@ -49,13 +51,13 @@ final class ChatViewController: ChatInterfaceViewController {
         chatViewModel.insertMessage(secondMessage)
     }
     
-    func bind() {
+    // MARK: Private
+    
+    private func bind() {
         chatViewModel.didTapImageUploadButton = { [weak self] in
             self?.presentPHPickerViewController()
         }
     }
-    
-    // MARK: Private
     
     private func setupNavigation() {
         setUpNavigationBarTitle()
@@ -91,9 +93,13 @@ final class ChatViewController: ChatInterfaceViewController {
     }
 }
 
-// MARK: PHPickerViewControllerDelegate 관련
+// MARK: PHPickerViewControllerDelegate
+
 extension ChatViewController: PHPickerViewControllerDelegate {
-    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+    func picker(
+        _ picker: PHPickerViewController,
+        didFinishPicking results: [PHPickerResult])
+    {
         if results.isEmpty {
             self.dismiss(animated: true)
         } else {
@@ -108,8 +114,8 @@ extension ChatViewController: PHPickerViewControllerDelegate {
         }
     }
     
-    private func presentPHPicekrViewController() {
-        let configuration = setupPHPicekrConfiguration()
+    private func presentPHPickerViewController() {
+        let configuration = setupPHPickerConfiguration()
         let phPickerViewController = PHPickerViewController(configuration: configuration)
         
         phPickerViewController.delegate = self
@@ -122,7 +128,7 @@ extension ChatViewController: PHPickerViewControllerDelegate {
         present(phPickerViewController, animated: true)
     }
     
-    private func setupPHPicekrConfiguration() -> PHPickerConfiguration {
+    private func setupPHPickerConfiguration() -> PHPickerConfiguration {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         
         configuration.filter = .images
@@ -132,7 +138,10 @@ extension ChatViewController: PHPickerViewControllerDelegate {
         return configuration
     }
     
-    private func getImage(results: [PHPickerResult], completion: @escaping (UIImage?) -> Void) {
+    private func getImage(
+        results: [PHPickerResult],
+        completion: @escaping (UIImage?) -> Void)
+    {
         var formattedImage: UIImage?
         guard let itemProvider = results.first?.itemProvider else { return }
         

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -19,6 +19,7 @@ final class ChatViewController: ChatInterfaceViewController {
         self.chatViewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         viewModel.delegate = chatInterfaceViewModel
+        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -48,8 +49,10 @@ final class ChatViewController: ChatInterfaceViewController {
         chatViewModel.insertMessage(secondMessage)
     }
     
-    override func didTapImageUploadButton() {
-        presentPHPicekrViewController()
+    func bind() {
+        chatViewModel.didTapImageUploadButton = { [weak self] in
+            self?.presentPHPickerViewController()
+        }
     }
     
     // MARK: Private

--- a/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/View/ChatViewController.swift
@@ -11,13 +11,14 @@ import MessageKit
 
 final class ChatViewController: ChatInterfaceViewController {
     
-    private let viewModel: ChatViewModel
+    private let chatViewModel: ChatViewModel
     
     // MARK: Lifecycle
     
     init(viewModel: ChatViewModel) {
-        self.viewModel = viewModel
+        self.chatViewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        viewModel.delegate = chatInterfaceViewModel
     }
     
     required init?(coder: NSCoder) {
@@ -35,8 +36,8 @@ final class ChatViewController: ChatInterfaceViewController {
             Tag(category: .theme, value: "아라아라라"),
             Tag(category: .theme, value: "아라라라라라"),
         ])
-        messageStorage.insertMessage(message)
-                              
+        chatViewModel.insertMessage(message)
+
         var recommendations: [RecommendationItem] = []
         let image = UIImage(systemName: "chevron.left")!
         let data = image.pngData()!
@@ -44,7 +45,7 @@ final class ChatViewController: ChatInterfaceViewController {
         recommendations.append(RecommendationItem(country: "아2폰나라", city: "아2폰시", spot: "아2폰", image: data))
         recommendations.append(RecommendationItem(country: "33333", city: "아이폰시", spot: "아이폰", image: data))
         let secondMessage = Message(recommendations: recommendations, sentDate: Date())
-        messageStorage.insertMessage(secondMessage)
+        chatViewModel.insertMessage(secondMessage)
     }
     
     override func didTapImageUploadButton() {
@@ -78,7 +79,7 @@ final class ChatViewController: ChatInterfaceViewController {
         
         return UIAction(image: backBarButtonImage) { [weak self] _ in
             guard let self else { return }
-            let popUpModels = self.viewModel.backButtonTapped()
+            let popUpModels = self.chatViewModel.backButtonTapped()
             self.showPopUp(
                 viewModel: popUpModels.viewModel,
                 type: popUpModels.type,
@@ -97,9 +98,8 @@ extension ChatViewController: PHPickerViewControllerDelegate {
                 self.getImage(results: results) { [weak self] image in
                     guard let self,
                           let image else { return }
-                    let message = self.viewModel.makePhotoMessage(image)
-                    
-                    self.messageStorage.insertMessage(message)
+                    self.chatViewModel.makePhotoMessage(image)
+                    // TODO: - API에 사진 전송
                 }
             }
         }
@@ -148,8 +148,10 @@ extension ChatViewController: PHPickerViewControllerDelegate {
     }
 }
 
+// MARK: PopUpViewControllerDelegate
+
 extension ChatViewController: PopUpViewControllerDelegate {
     func pop() {
-        viewModel.pop()
+        chatViewModel.pop()
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -9,3 +9,11 @@ final class ChatInterfaceViewModel {
     
     let messageStorage: MessageStorage = MessageStorage()
 }
+
+// MARK: MessageStorageDelegate
+
+extension ChatInterfaceViewModel: MessageStorageDelegate {
+    func insert(message: Message) {
+        messageStorage.insertMessage(message)
+    }
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatInterfaceViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  ChatInterfaceViewModel.swift
+//  TravelGenie
+//
+//  Created by summercat on 2023/08/28.
+//
+
+final class ChatInterfaceViewModel {
+    
+    let messageStorage: MessageStorage = MessageStorage()
+}

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -69,12 +69,6 @@ final class ChatViewModel {
             leftButtonTitle: leftButtonTitle,
             rightButtonTitle: rightButtonTitle)
     }
-}
 
-// MARK: TagSubmissionDelegate
-
-extension ChatViewModel: TagSubmissionDelegate {
-    func submitSelectedTags(_ selectedTags: [Tag]) {
-        self.requestRecommendations(with: selectedTags)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -15,12 +15,18 @@ final class ChatViewModel {
     
     weak var coordinator: ChatCoordinator?
     weak var delegate: MessageStorageDelegate?
+    var didTapImageUploadButton: (() -> Void)?
     
     private let user: Sender = Sender(name: .user)
     
     // MARK: Lifecycle
     
     init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didTapImageUploadButton(notification:)),
+            name: .imageUploadButtonTapped,
+            object: nil)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(submitSelectedTags(notification:)),
@@ -82,6 +88,9 @@ final class ChatViewModel {
     
     // MARK: objc methods
     
+    @objc private func didTapImageUploadButton(notification: Notification) {
+        didTapImageUploadButton?()
+    }
 
     @objc private func submitSelectedTags(notification: Notification) {
         guard let selectedTags = notification.userInfo?[NotificationKey.selectedTags] as? [Tag] else { return }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -7,17 +7,29 @@
 
 import UIKit
 
+protocol MessageStorageDelegate: AnyObject {
+    func insert(message: Message)
+}
+
 final class ChatViewModel {
     
     weak var coordinator: ChatCoordinator?
+    weak var delegate: MessageStorageDelegate?
     
     private let user: Sender = Sender(name: .user)
     
-    func makePhotoMessage(_ image: UIImage) -> Message {
-        return Message(
+    // MARK: Internal
+    
+    func insertMessage(_ message: Message) {
+        delegate?.insert(message: message)
+    }
+    
+    func makePhotoMessage(_ image: UIImage) {
+        let message = Message(
             image: image,
             sender: self.user,
             sentDate: Date())
+        delegate?.insert(message: message)
     }
     
     func backButtonTapped() -> (viewModel: PopUpViewModel, type: PopUpContentView.PopUpType) {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -31,6 +31,12 @@ final class ChatViewModel {
         coordinator?.finish()
     }
     
+    private func requestRecommendations(with tags: [Tag]) {
+        let keywords: [String] = tags.map { $0.value }
+        
+        // TODO: - ChatGPT에 keyword 넣어서 요청 보내기
+    }
+    
     private func createPopUpViewModel() -> PopUpViewModel {
         return PopUpViewModel()
     }
@@ -50,5 +56,13 @@ final class ChatViewModel {
             mainText: mainText,
             leftButtonTitle: leftButtonTitle,
             rightButtonTitle: rightButtonTitle)
+    }
+}
+
+// MARK: TagSubmissionDelegate
+
+extension ChatViewModel: TagSubmissionDelegate {
+    func submitSelectedTags(_ selectedTags: [Tag]) {
+        self.requestRecommendations(with: selectedTags)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -59,9 +59,10 @@ final class ChatViewModel {
         coordinator?.finish()
     }
     
+    // MARK: Private
+    
     private func requestRecommendations(with tags: [Tag]) {
         let keywords: [String] = tags.map { $0.value }
-        
         // TODO: - ChatGPT에 keyword 넣어서 요청 보내기
     }
     

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -18,6 +18,16 @@ final class ChatViewModel {
     
     private let user: Sender = Sender(name: .user)
     
+    // MARK: Lifecycle
+    
+    init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(submitSelectedTags(notification:)),
+            name: .tagSubmitButtonTapped,
+            object: nil)
+    }
+    
     // MARK: Internal
     
     func insertMessage(_ message: Message) {
@@ -69,6 +79,12 @@ final class ChatViewModel {
             leftButtonTitle: leftButtonTitle,
             rightButtonTitle: rightButtonTitle)
     }
+    
+    // MARK: objc methods
+    
 
+    @objc private func submitSelectedTags(notification: Notification) {
+        guard let selectedTags = notification.userInfo?[NotificationKey.selectedTags] as? [Tag] else { return }
+        requestRecommendations(with: selectedTags)
     }
 }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -10,6 +10,8 @@ import Foundation
 final class CustomTagContentCellViewModel {
     private let tagStorage: TagStorage = TagStorage()
     
+    weak var delegate: TagSubmissionDelegate?
+    
     var locationTagListCount: Int {
         return tagStorage.locationTags.count
     }
@@ -47,6 +49,10 @@ final class CustomTagContentCellViewModel {
     
     func updateTagIsSelected(value: String, isSelected: Bool) {
         tagStorage.updateTagSelectionState(value: value, isSelected: isSelected)
+    }
+    
+    func submitSelectedTags(_ selectedTags: [Tag]) {
+        delegate?.submitSelectedTags(selectedTags)
     }
     
     func cellSizeForSection(indexPath: IndexPath) -> CGSize {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -8,9 +8,6 @@
 import Foundation
 
 final class CustomTagContentCellViewModel {
-    private let tagStorage: TagStorage = TagStorage()
-    
-    weak var delegate: TagSubmissionDelegate?
     
     var locationTagListCount: Int {
         return tagStorage.locationTags.count
@@ -32,6 +29,8 @@ final class CustomTagContentCellViewModel {
         return ["✈️지역", "⛵️테마"]
     }
     
+    private let tagStorage: TagStorage = TagStorage()
+    
     // MARK: Internal
     
     func insertTags(tags: [Tag]) {
@@ -52,7 +51,6 @@ final class CustomTagContentCellViewModel {
     }
     
     func submitSelectedTags(_ selectedTags: [Tag]) {
-        delegate?.submitSelectedTags(selectedTags)
     }
     
     func cellSizeForSection(indexPath: IndexPath) -> CGSize {

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/CustomTagContentCellViewModel.swift
@@ -51,6 +51,10 @@ final class CustomTagContentCellViewModel {
     }
     
     func submitSelectedTags(_ selectedTags: [Tag]) {
+        NotificationCenter.default.post(
+            name: .tagSubmitButtonTapped,
+            object: self,
+            userInfo: [NotificationKey.selectedTags: selectedTags])
     }
     
     func cellSizeForSection(indexPath: IndexPath) -> CGSize {

--- a/TravelGenie/TravelGenie/Presentation/ChatList/ViewModel/ChatListViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/ChatList/ViewModel/ChatListViewModel.swift
@@ -11,10 +11,10 @@ final class ChatListViewModel {
     
     weak var coordinator: ChatListCoordinator?
     
-    private let chatUseCase: ChatUseCase
-    
     var emptyChat: ((Bool) -> Void)?
     var chatsDelivered: (([Chat]) -> Void)?
+    
+    private let chatUseCase: ChatUseCase
     private(set) var chats: [Chat] = [] {
         didSet {
             emptyChat?(chats.isEmpty)

--- a/TravelGenie/TravelGenie/Presentation/Common/NotificationName+swift.swift
+++ b/TravelGenie/TravelGenie/Presentation/Common/NotificationName+swift.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension Notification.Name {
+    static let imageUploadButtonTapped = Notification.Name("imageUploadButtonTapped")
     static let tagSubmitButtonTapped = Notification.Name("tagSubmitButtonTapped")
 }
 

--- a/TravelGenie/TravelGenie/Presentation/Common/NotificationName+swift.swift
+++ b/TravelGenie/TravelGenie/Presentation/Common/NotificationName+swift.swift
@@ -1,0 +1,16 @@
+//
+//  NotificationName+swift.swift
+//  TravelGenie
+//
+//  Created by summercat on 2023/08/28.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let tagSubmitButtonTapped = Notification.Name("tagSubmitButtonTapped")
+}
+
+enum NotificationKey {
+    case selectedTags
+}


### PR DESCRIPTION
Resolves #40 

- ChatInterfaceVC, ChatVC, ChatInterfaceVM, ChatVM간 역할 분리
    - `MessageStorage`를 `ChatInterfaceVM`에서 관리하도록 리팩토링
- NotificationCenter를 사용해 `이미지 업로드` 버튼 탭, `키워드 보내기` 버튼 탭 이벤트 전달
- 컨벤션에 맞게 주석 추가
- 업로드 버튼을 사전 구현된 `RectangleTextButton` 컴포넌트를 이용하도록 리팩토링