### PR TITLE
Feature/23/RecommendationItem 생성 기능 구현

### DIFF
--- a/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
+++ b/TravelGenie/TravelGenie.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		57DA98782A9E4B420074409B /* DefaultImageSearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA98772A9E4B420074409B /* DefaultImageSearchRepository.swift */; };
 		57DA987A2A9F00B30074409B /* ImageSearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA98792A9F00B30074409B /* ImageSearchUseCase.swift */; };
 		57DA98882A9F81300074409B /* OpenAIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA98872A9F81300074409B /* OpenAIRepository.swift */; };
+		57DA988B2A9F8C830074409B /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA988A2A9F8C830074409B /* ImageManager.swift */; };
 		D20FA2732A6B8DA90081B039 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2722A6B8DA90081B039 /* AppDelegate.swift */; };
 		D20FA2752A6B8DA90081B039 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FA2742A6B8DA90081B039 /* SceneDelegate.swift */; };
 		D20FA27C2A6B8DAC0081B039 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D20FA27B2A6B8DAC0081B039 /* Assets.xcassets */; };
@@ -182,6 +183,7 @@
 		57DA98772A9E4B420074409B /* DefaultImageSearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageSearchRepository.swift; sourceTree = "<group>"; };
 		57DA98792A9F00B30074409B /* ImageSearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSearchUseCase.swift; sourceTree = "<group>"; };
 		57DA98872A9F81300074409B /* OpenAIRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenAIRepository.swift; sourceTree = "<group>"; };
+		57DA988A2A9F8C830074409B /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		D20FA26F2A6B8DA90081B039 /* TravelGenie.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TravelGenie.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D20FA2722A6B8DA90081B039 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D20FA2742A6B8DA90081B039 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -467,6 +469,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		57DA98892A9F8C770074409B /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				57DA988A2A9F8C830074409B /* ImageManager.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
 		D20FA2662A6B8DA90081B039 = {
 			isa = PBXGroup;
 			children = (
@@ -486,6 +496,7 @@
 		D20FA2712A6B8DA90081B039 /* TravelGenie */ = {
 			isa = PBXGroup;
 			children = (
+				57DA98892A9F8C770074409B /* Utility */,
 				D20FA2862A6B97A70081B039 /* Presentation */,
 				D20FA2872A6B97B90081B039 /* Domain */,
 				D20FA2882A6B97C20081B039 /* Data */,
@@ -852,6 +863,7 @@
 				D2E3AA282A8B62400049DDEF /* ChatViewModel.swift in Sources */,
 				57462B6F2A95EAF700949D5C /* ChatEntity+CoreDataProperties.swift in Sources */,
 				57462B442A94F92A00949D5C /* MessageKind+description.swift in Sources */,
+				57DA988B2A9F8C830074409B /* ImageManager.swift in Sources */,
 				57462B272A94E9B600949D5C /* ChatStorage.swift in Sources */,
 				D20FA2AB2A6BE34D0081B039 /* Encodable+toDictionary.swift in Sources */,
 				573BCD1D2A8E682200116D2D /* BottomMenuItem.swift in Sources */,

--- a/TravelGenie/TravelGenie/Data/Repository/DefaultImageSearchRepository.swift
+++ b/TravelGenie/TravelGenie/Data/Repository/DefaultImageSearchRepository.swift
@@ -11,12 +11,13 @@ final class DefaultImageSearchRepository: ImageSearchRepository {
     
     private let networkService = NetworkService()
     
-    // TODO: - 넣어줄 Info 타입 정의
     func searchImage(
-        _ info: String,
+        with tags: [Tag],
+        spot: String,
         completion: @escaping (Result<String, Error>) -> Void)
     {
-        let requestModel = ImageSearchRequestModel(q: "", exactTerms: "")
+        let query = tags.map { $0.value }.joined(separator: " ")
+        let requestModel = ImageSearchRequestModel(q: query, exactTerms: spot)
         networkService.request(GoogleCustomSearchAPI.imageSearch(requestModel)) { result in
             switch result {
             case .success(let response):

--- a/TravelGenie/TravelGenie/Domain/RepositoryInterface/ImageSearchRepository.swift
+++ b/TravelGenie/TravelGenie/Domain/RepositoryInterface/ImageSearchRepository.swift
@@ -7,6 +7,7 @@
 
 protocol ImageSearchRepository {
     func searchImage(
-        _ info: String,
+        with tags: [Tag],
+        spot: String,
         completion: @escaping (Result<String, Error>) -> Void)
 }

--- a/TravelGenie/TravelGenie/Domain/UseCase/ImageSearchUseCase.swift
+++ b/TravelGenie/TravelGenie/Domain/UseCase/ImageSearchUseCase.swift
@@ -5,10 +5,13 @@
 //  Created by summercat on 2023/08/30.
 //
 
+import Foundation
+
 protocol ImageSearchUseCase {
     func searchImage(
-        _ info: String,
-        completion: @escaping (Result<String, Error>) -> Void)
+        with tags: [Tag],
+        spot: String,
+        completion: @escaping (Result<Data, Error>) -> Void)
 }
 
 final class DefaultImageSearchUseCase: ImageSearchUseCase {
@@ -20,13 +23,17 @@ final class DefaultImageSearchUseCase: ImageSearchUseCase {
     }
     
     func searchImage(
-        _ info: String,
-        completion: @escaping (Result<String, Error>) -> Void)
+        with tags: [Tag],
+        spot: String,
+        completion: @escaping (Result<Data, Error>) -> Void)
     {
-        repository.searchImage(info) { result in
+        let themeTags = tags.filter { $0.category == .theme }
+        repository.searchImage(with: themeTags, spot: spot) { result in
             switch result {
             case .success(let imageURL):
-                completion(.success(imageURL))
+                ImageManager.retrieveImage(with: imageURL) { data in
+                    completion(.success(data))
+                }
             case .failure(let error):
                 completion(.failure(error))
             }

--- a/TravelGenie/TravelGenie/Presentation/Chat/ChatCoordinator.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ChatCoordinator.swift
@@ -23,7 +23,9 @@ final class ChatCoordinator: Coordinator {
             chatUseCase: DefaultChatUseCase(
                 chatRepository: DefaultChatRepository()),
             openAIUseCase: DefaultOpenAIUseCase(
-                openAIRepository: DefaultOpenAIRepository()))
+                openAIRepository: DefaultOpenAIRepository()),
+            imageSearchUseCase: DefaultImageSearchUseCase(
+                repository: DefaultImageSearchRepository()))
         let chatViewController = ChatViewController(viewModel: chatViewModel)
         chatViewModel.coordinator = self
         navigationController?.pushViewController(chatViewController, animated: false)

--- a/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/TravelGenie/TravelGenie/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -49,7 +49,6 @@ final class ChatViewModel {
     }
     
     private struct OpenAIRecommendation: Decodable {
-        
         struct RecommendationItem: Decodable {
             let country: String
             let spot: String
@@ -133,8 +132,20 @@ final class ChatViewModel {
     
     // MARK: Private
     
+    // MARK: Message
+    
     private func insertMessage(_ message: Message) {
         delegate?.insert(message: message)
+    }
+    
+    private func createTextMessage(with text: String, sender: Sender) -> Message {
+        let textColor: UIColor = sender == ai ? .black : .white
+        let messageText = NSMutableAttributedString()
+            .text(text, font: .bodyRegular, color: textColor)
+        return Message(
+            text: messageText,
+            sender: sender,
+            sentDate: Date())
     }
     
     private func createRecommendationMessage(with result: OpenAIRecommendation) -> Message {
@@ -158,6 +169,9 @@ final class ChatViewModel {
             }
         }
     }
+    
+    // MARK: OpenAI
+    
     private func addDefaultOpenAIPropmpt() {
         let message = ChatMessage(role: .system, content: OpenAIPrompt.openAISystemPrompt)
         openAIChatMessages.append(message)
@@ -198,22 +212,7 @@ final class ChatViewModel {
         }
     }
     
-    private func createTextMessage(with text: String, sender: Sender) -> Message {
-        let textColor: UIColor = sender == ai ? .black : .white
-        let messageText = NSMutableAttributedString()
-            .text(text, font: .bodyRegular, color: textColor)
-        return Message(
-            text: messageText,
-            sender: sender,
-            sentDate: Date())
-    }
-    
-    // TODO: - 사진 API를 통해 사진 가져와서 RecommendationItem 생성
-    private func createRecommendationMessage(with result: OpenAIRecommendation) -> Message {
-        
-        // 메시지는 [RecommendationItem]을 받아서 만든다.
-        return Message(sender: ai, sentDate: Date())
-    }
+    // MARK: PopUp
     
     private func createPopUpViewModel() -> PopUpViewModel {
         return PopUpViewModel()
@@ -235,6 +234,8 @@ final class ChatViewModel {
             leftButtonTitle: leftButtonTitle,
             rightButtonTitle: rightButtonTitle)
     }
+    
+    // MARK: Chat
     
     private func isValidChat() -> Bool {
         return !selectedTags.isEmpty && !recommendationItems.isEmpty

--- a/TravelGenie/TravelGenie/Utility/ImageManager.swift
+++ b/TravelGenie/TravelGenie/Utility/ImageManager.swift
@@ -1,0 +1,49 @@
+//
+//  ImageManager.swift
+//  TravelGenie
+//
+//  Created by summercat on 2023/08/30.
+//
+
+import Foundation
+
+final class ImageManager {
+    static let cache: URLCache = URLCache()
+    
+    static func retrieveImage(
+        with url: String,
+        completion: @escaping (Data) -> Void
+    ) {
+        guard let url = URL(string: url) else { return }
+        
+        let request: URLRequest = URLRequest(url: url)
+        if let data = loadImageFromCache(with: request) {
+            completion(data)
+        } else {
+            downloadImage(with: request) { data in
+                completion(data)
+            }
+        }
+    }
+    
+    private static func loadImageFromCache(with request: URLRequest) -> Data? {
+        return cache.cachedResponse(for: request)?.data
+    }
+    
+    private static func downloadImage(
+        with request: URLRequest,
+        completion: @escaping (Data) -> Void
+    ) {
+        let task = URLSession.shared.dataTask(with: request) { data, response, _ in
+            guard let data = data,
+                  let response = response as? HTTPURLResponse,
+                  (200..<300) ~= response.statusCode else { return }
+            
+            let cachedResponse: CachedURLResponse = CachedURLResponse(response: response, data: data)
+            cache.storeCachedResponse(cachedResponse, for: request)
+            
+            completion(data)
+        }
+        task.resume()
+    }
+}


### PR DESCRIPTION
Resolves #48 

- [x] ChatGPT에서 받은 추천 결과를 기반으로 ImageSearch를 통해 이미지 받아오기
  - 추천해준 명소(`spot`)은 반드시 포함해야 하는 키워드, 나머지 테마 태그는 쿼리에 넣어 검색
  - 받아온 결과값에서 이미지 URL을 추출
  - 추출한 이미지 URL은 `ImageManager`에서 다운로드 및 캐싱
- [x] 받아온 이미지와 ChatGPT의 추천 결과를 합쳐서 RecommendationItem 생성하기
- [x] RecommendationItem 메시지 생성하기
  - 생성 후 `messageStorage`에 메시지를 `insert`하는 동작까지 완료