### PR TITLE
Fix/30/MessageKind의 description이 연관값은 포함하지 않도록 수정

### DIFF
--- a/TravelGenie/TravelGenie/Data/Extensions/MessageKind+description.swift
+++ b/TravelGenie/TravelGenie/Data/Extensions/MessageKind+description.swift
@@ -11,6 +11,10 @@ import MessageKit
 extension MessageKind {
     var description: String {
         switch self {
+        case .attributedText:
+            return "attributedText"
+        case .photo:
+            return "photo"
         case .custom(let item):
             if item is TagItem { return "tag" }
             else if item is [RecommendationItem] { return "recommendation" }


### PR DESCRIPTION
- CoreData에 저장 시 연관값을 함께 저장하게 되어 CoreData Entity에서 Domain 모델로의 변환이 실패하는 문제 해결